### PR TITLE
Cannot use the migrator on subwikis #18 

### DIFF
--- a/application-confluence-migrator-pro-default/pom.xml
+++ b/application-confluence-migrator-pro-default/pom.xml
@@ -29,6 +29,9 @@
   </parent>
   <artifactId>application-confluence-migrator-pro-default</artifactId>
   <name>Confluence Migrator Pro - Default API</name>
+  <properties>
+    <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.xwiki.confluencepro</groupId>


### PR DESCRIPTION
* The context of the filtering job lacked information about the wiki in which it was being executed.
* The ConfluenceFilteringListener, responsible with asking the job question, would not trigger unless the default api module was installed on root.