### PR TITLE
#40 Confluence details are not stored by default

### DIFF
--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
@@ -46,6 +46,7 @@
 #set ($discard = $xwiki.jsx.use('ConfluenceMigratorPro.Code.JobDoneEventEmitter'))
 #set ($prefilledValues = {
   'input': {
+    'storeConfluenceDetailsEnabled': 'true',
     'prefixedMacros': 'attachments,gallery,chart'
   },
   'output': {


### PR DESCRIPTION
#40

Since this is an important change in the default behavior of the confluence migrator pro, I'm pushing this to review.

I would pretty much like to be able to query Confluence data so we can implement some useful subset of CQL, used in some confluence macros we might want to support. This data is only there if we enable this option.

However, this adds an object per page, which can be heavy.