### PR TITLE
Make it mandatory to run Confluence Migrator Pro from the main wiki, …

### DIFF
--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/CommonCode.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/CommonCode.xml
@@ -365,6 +365,17 @@
     #end
   #end
 #end
+#**
+ * Display an info box informing the user that migrations are managed on the main wiki.
+ *#
+#macro(displayMainWikiInfoBox)
+  #set ($label = $services.rendering.escape($services.localization.render("confluencepro.extension.notMainWiki.link.label"), $xwiki.currentContentSyntaxId))
+  #set ($message = $services.localization.render("confluencepro.extension.notMainWiki", $xwiki.currentContentSyntaxId, ['MAIN_LINK']))
+  #set ($link = "[[$label&gt;&gt;$xcontext.mainWikiName:ConfluenceMigratorPro.WebHome]]")
+  {{info}}
+    $message.replace('MAIN_LINK', $link)
+  {{/info}}
+#end
 {{/velocity}}</content>
   <object>
     <name>ConfluenceMigratorPro.Code.CommonCode</name>

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
@@ -886,7 +886,11 @@
 
 {{velocity}}
 #set ($discard = $doc.use('ConfluenceMigratorPro.Code.MigrationClass'))
-#if ($xcontext.action == 'edit' || $xcontext.action == 'admin')
+#if (!$xcontext.isMainWiki())
+  {{info}}
+    {{translation key="confluencepro.extension.notMainWiki"/}}
+  {{/info}}
+#elseif ($xcontext.action == 'edit' || $xcontext.action == 'admin')
   #if ($doc.isNew())
     #newDocView
   #else

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
@@ -887,9 +887,7 @@
 {{velocity}}
 #set ($discard = $doc.use('ConfluenceMigratorPro.Code.MigrationClass'))
 #if (!$xcontext.isMainWiki())
-  {{info}}
-    {{translation key="confluencepro.extension.notMainWiki"/}}
-  {{/info}}
+  #displayMainWikiInfoBox
 #elseif ($xcontext.action == 'edit' || $xcontext.action == 'admin')
   #if ($doc.isNew())
     #newDocView

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Translations.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Translations.xml
@@ -41,6 +41,7 @@ confluencepro.extension.name=Confluence Migrator Pro
 
 confluencepro.extension.missingLicense=The application is running in trial mode. In order to unlock the full capabilities please obtain a license from the {0}.
 confluencepro.extension.missingLicense.label=administration section
+confluencepro.extension.notMainWiki=Confluence Migrations are managed on the main wiki.
 
 confluencepro.zippicker.title=Select a confluence package to start the migration
 confluencepro.zippicker.placeholder=Pick a confluence export package...

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Translations.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Translations.xml
@@ -41,7 +41,8 @@ confluencepro.extension.name=Confluence Migrator Pro
 
 confluencepro.extension.missingLicense=The application is running in trial mode. In order to unlock the full capabilities please obtain a license from the {0}.
 confluencepro.extension.missingLicense.label=administration section
-confluencepro.extension.notMainWiki=Confluence Migrations are managed on the main wiki.
+confluencepro.extension.notMainWiki=Confluence Migrations are managed on the {0}.
+confluencepro.extension.notMainWiki.link.label=main wiki
 
 confluencepro.zippicker.title=Select a confluence package to start the migration
 confluencepro.zippicker.placeholder=Pick a confluence export package...

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Migrations/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Migrations/WebHome.xml
@@ -40,11 +40,9 @@
 
 {{velocity}}
 #if (!$xcontext.isMainWiki())
-  {{info}}
-    {{translation key="confluencepro.extension.notMainWiki"/}}
-  {{/info}}
+  #displayMainWikiInfoBox
 #else
-    #displayMigrationsLiveData
+  #displayMigrationsLiveData
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Migrations/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Migrations/WebHome.xml
@@ -39,6 +39,12 @@
   <content>{{include reference="ConfluenceMigratorPro.Code.CommonCode" /}}
 
 {{velocity}}
-#displayMigrationsLiveData
+#if (!$xcontext.isMainWiki())
+  {{info}}
+    {{translation key="confluencepro.extension.notMainWiki"/}}
+  {{/info}}
+#else
+    #displayMigrationsLiveData
+#end
 {{/velocity}}</content>
 </xwikidoc>

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
@@ -45,6 +45,10 @@
 #set ($mainReference = $services.model.createDocumentReference('', ['ConfluenceMigratorPro', 'Code'], 'MigrationClass'))
 #if (!$services.licensing.licensor.hasLicensureForEntity($mainReference))
   {{missingLicenseMessage extensionName="confluencepro.extension.name"/}}
+#elseif (!$xcontext.isMainWiki())
+  {{info}}
+    {{translation key="confluencepro.extension.notMainWiki"/}}
+  {{/info}}
 #else
 #set ($license = $services.licensing.licensor.getLicenseForEntity($mainReference))
 #if ($license.type == 'TRIAL')

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
@@ -46,9 +46,7 @@
 #if (!$services.licensing.licensor.hasLicensureForEntity($mainReference))
   {{missingLicenseMessage extensionName="confluencepro.extension.name"/}}
 #elseif (!$xcontext.isMainWiki())
-  {{info}}
-    {{translation key="confluencepro.extension.notMainWiki"/}}
-  {{/info}}
+  #displayMainWikiInfoBox
 #else
 #set ($license = $services.licensing.licensor.getLicenseForEntity($mainReference))
 #if ($license.type == 'TRIAL')


### PR DESCRIPTION
…or test whether it works fine when run from a subwiki and support this #216

Limited the migrator to be run only on the main wiki.

Installing the app on a subwiki and visiting the application home page will display an information box.

![image](https://github.com/user-attachments/assets/fe0a182d-e740-4f60-a69c-a1b816bf9571)

Clicking on the "main wiki" will take the user to the Confluence Migrator installed on the main wiki.