### PR TITLE
Correct styling for Batch sources #281

### DIFF
--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/ConfluenceBatches/Create.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/ConfluenceBatches/Create.xml
@@ -68,8 +68,8 @@
 #macro (prepareSourcesDisplay $sources)
   #set ($sourceDisplayer = "")
   #foreach($source in $sources)
-    #set ($sourceDisplayer =$sourceDisplayer + "&lt;span class='cmpBatchCreateBold' &gt;#$foreach.index &lt;/span&gt;
-     $escapetool.xml($services.rendering.escape($source, 'xwiki/2.1'))&lt;br/&gt;")
+    #set ($sourceDisplayer = $sourceDisplayer + "&lt;span class='cmpBatchCreateBold' &gt;#$foreach.index &lt;/span&gt;
+      $escapetool.xml($services.rendering.escape($source, 'xwiki/2.1'))&lt;br/&gt;")
   #end
 #end
 

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/ConfluenceBatches/Create.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/ConfluenceBatches/Create.xml
@@ -69,7 +69,7 @@
   #set ($sourceDisplayer = "")
   #foreach($source in $sources)
     #set ($sourceDisplayer =$sourceDisplayer + "&lt;span class='cmpBatchCreateBold' &gt;#$foreach.index &lt;/span&gt;
-    $escapetool.xml($source)&lt;br/&gt;")
+     $escapetool.xml($services.rendering.escape($source, 'xwiki/2.1'))&lt;br/&gt;")
   #end
 #end
 
@@ -97,7 +97,7 @@
     &lt;span class="cmpBatchCreateTitle"&gt;$escapetool.xml("$services.localization.render($translationKey)")&lt;/span&gt;
     &lt;div #if($overflow) class='cmpBatchCreateOverflow' #end&gt;
       #foreach ($file in $files)
-        &lt;span&gt;$services.rendering.escape($file, 'xwiki/2.1') &lt;br/&gt;&lt;/span&gt;
+        &lt;span&gt;$escapetool.xml($services.rendering.escape($file, 'xwiki/2.1'))&lt;br/&gt;&lt;/span&gt;
       #end
     &lt;/div&gt;
   &lt;/div&gt;


### PR DESCRIPTION
To properly display the file names, I have to escape them for both html and velocity since I use xwiki syntax in the HTML to properly display the json files