### PR TITLE
Convert tasklist macro into task macros #317

### DIFF
--- a/application-confluence-migrator-pro-converters/pom.xml
+++ b/application-confluence-migrator-pro-converters/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
     <xwiki.jacoco.instructionRatio>0.67</xwiki.jacoco.instructionRatio>
-    <taskapplication.version>3.5.1</taskapplication.version>
+    <taskapplication.version>3.7.0</taskapplication.version>
   </properties>
   <dependencies>
     <dependency>

--- a/application-confluence-migrator-pro-converters/src/main/java/com/xwiki/confluencepro/converters/internal/LegacyTaskListMacroConverter.java
+++ b/application-confluence-migrator-pro-converters/src/main/java/com/xwiki/confluencepro/converters/internal/LegacyTaskListMacroConverter.java
@@ -1,0 +1,222 @@
+package com.xwiki.confluencepro.converters.internal;
+
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import java.io.StringReader;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.contrib.confluence.filter.input.ConfluenceInputContext;
+import org.xwiki.contrib.confluence.filter.internal.input.ConfluenceConverter;
+import org.xwiki.contrib.confluence.filter.internal.macros.AbstractMacroConverter;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.block.ParagraphBlock;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.listener.Format;
+import org.xwiki.rendering.listener.Listener;
+import org.xwiki.rendering.parser.ParseException;
+import org.xwiki.rendering.parser.Parser;
+import org.xwiki.rendering.renderer.BlockRenderer;
+import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
+import org.xwiki.rendering.renderer.printer.WikiPrinter;
+
+import com.xwiki.date.DateMacroConfiguration;
+import com.xwiki.task.TaskConfiguration;
+import com.xwiki.task.model.Task;
+
+/**
+ * Convert the legacy tasklist macro into a series of task macro calls.
+ *
+ * @version $Id$
+ * @since 1.34.0
+ */
+@Component
+@Singleton
+@Named("tasklist")
+public class LegacyTaskListMacroConverter extends AbstractMacroConverter
+{
+    private static final String PARAM_PRIORITY = "priority";
+
+    private static final String PARAM_LOCKED = "locked";
+
+    @Inject
+    private TaskConfiguration taskConfiguration;
+
+    @Inject
+    private DateMacroConfiguration dateMacroConfiguration;
+
+    @Inject
+    private ConfluenceConverter confluenceConverter;
+
+    @Inject
+    @Named("xwiki/2.1")
+    private BlockRenderer blockRenderer;
+
+    @Inject
+    @Named("plain/1.0")
+    private Parser plainParser;
+
+    @Inject
+    private ConfluenceInputContext context;
+
+    @Inject
+    private Logger logger;
+
+    private Map<Long, Integer> legacyMacrosIdCounter = new HashMap<>();
+
+    @Override
+    public void toXWiki(String confluenceId, Map<String, String> confluenceParameters, String confluenceContent,
+        boolean inline, Listener listener)
+    {
+        List<Map<String, String>> taskList = new ArrayList<>();
+        for (String line : confluenceContent.split("\n")) {
+            if (line.trim().isEmpty() || line.startsWith("||")) {
+                continue;
+            }
+            Map<String, String> task = new HashMap<>();
+            String[] properties = line.substring(1).split("\\|");
+            maybePutFromArray(0, properties, task, Task.STATUS);
+            maybePutFromArray(1, properties, task, PARAM_PRIORITY);
+            maybePutFromArray(2, properties, task, PARAM_LOCKED);
+            maybePutFromArray(3, properties, task, Task.CREATE_DATE);
+            maybePutFromArray(4, properties, task, Task.COMPLETE_DATE);
+            maybePutFromArray(5, properties, task, Task.ASSIGNEE);
+            maybePutFromArray(6, properties, task, Task.NAME);
+
+            if (!task.isEmpty()) {
+                taskList.add(task);
+            }
+        }
+        SimpleDateFormat storageDateFormat = new SimpleDateFormat(dateMacroConfiguration.getStorageDateFormat());
+        String title = confluenceParameters.remove("title");
+        // Can't handle these parameters.
+        confluenceParameters.remove("promptOnDelete");
+        confluenceParameters.remove("enableLocking");
+        listener.beginGroup(confluenceParameters);
+        maybeTraverseTitle(listener, title);
+        for (Map<String, String> task : taskList) {
+            toXWikiTask(task, storageDateFormat);
+
+            int refSuffix = legacyMacrosIdCounter.getOrDefault(context.getCurrentPage(), 0);
+            legacyMacrosIdCounter.put(context.getCurrentPage(), refSuffix + 1);
+            task.put(Task.REFERENCE, "/Tasks/Task_Legacy_" + refSuffix);
+            listener.onMacro("task", task, task.remove(Task.NAME), false);
+        }
+        listener.endGroup(confluenceParameters);
+    }
+
+    private void maybeTraverseTitle(Listener listener, String title)
+    {
+        if (title != null && !title.trim().isEmpty()) {
+            try {
+                listener.beginParagraph(Collections.emptyMap());
+                listener.beginFormat(Format.BOLD, Collections.emptyMap());
+                XDOM titleXDOM = plainParser.parse(new StringReader(title));
+                List<Block> blockToTraverse = titleXDOM.getChildren();
+                if (!blockToTraverse.isEmpty() && blockToTraverse.get(0) instanceof ParagraphBlock) {
+                    blockToTraverse = blockToTraverse.get(0).getChildren();
+                }
+                blockToTraverse.forEach(child -> child.traverse(listener));
+                listener.endFormat(Format.BOLD, Collections.emptyMap());
+                listener.endParagraph(Collections.emptyMap());
+            } catch (ParseException e) {
+                logger.warn("Failed to parse the title [{}] of the tasklist confluence macro. Cause: [{}]",
+                    title, ExceptionUtils.getRootCauseMessage(e));
+            }
+        }
+    }
+
+    private void maybePutFromArray(int index, String[] properties, Map<String, String> task, String propName)
+    {
+        try {
+            String property = properties[index];
+            if (property.trim().isEmpty()) {
+                return;
+            }
+            task.put(propName, property);
+        } catch (IndexOutOfBoundsException e) {
+            // If the data is consistent with the example, it shouldn't happen.
+            logger.warn("There is no property at index [{}].", index);
+        }
+    }
+
+    private void toXWikiTask(Map<String, String> task, SimpleDateFormat storageDateFormat)
+    {
+        // We can't handle these parameters in the Task Manager application.
+        task.remove(PARAM_PRIORITY);
+        task.remove(PARAM_LOCKED);
+
+        String xwikiStatus = task.getOrDefault(Task.STATUS, "");
+        xwikiStatus = xwikiStatus.equals("T") ? Task.STATUS_DONE : taskConfiguration.getDefaultInlineStatus();
+        task.put(Task.STATUS, xwikiStatus);
+
+        maybeUpdateDateProperty(Task.CREATE_DATE, task, storageDateFormat);
+        maybeUpdateDateProperty(Task.COMPLETE_DATE, task, storageDateFormat);
+
+        String content = task.getOrDefault(Task.NAME, "");
+
+        String assignee = task.remove(Task.ASSIGNEE);
+        if (assignee != null && !assignee.trim().isEmpty()) {
+            assignee = confluenceConverter.convertUserReference(assignee);
+            if (assignee != null) {
+                Map<String, String> mentionParams = new HashMap<>();
+                mentionParams.put("style", "FULL_NAME");
+                mentionParams.put(Task.REFERENCE, assignee);
+                mentionParams.put("anchor",
+                    String.join("-",
+                        assignee.replace('.', '-'),
+                        "legacy",
+                        legacyMacrosIdCounter.getOrDefault(context.getCurrentPage(), 0).toString()));
+                MacroBlock mentionBlock = new MacroBlock("mention", mentionParams, true);
+                WikiPrinter printer = new DefaultWikiPrinter(new StringBuffer());
+                blockRenderer.render(Collections.singletonList(mentionBlock), printer);
+                content = String.join(" ", content, printer.toString());
+            }
+        }
+        task.put(Task.NAME, content);
+    }
+
+    private void maybeUpdateDateProperty(String key, Map<String, String> task, SimpleDateFormat storageDateFormat)
+    {
+        try {
+            String serializedCreateDate = task.getOrDefault(key, "");
+            if (!serializedCreateDate.trim().isEmpty()) {
+                Date date = new Date(Long.parseLong(serializedCreateDate.trim()));
+                task.put(key, storageDateFormat.format(date));
+            }
+        } catch (NumberFormatException e) {
+            logger.warn("Failed to parse the date [{}] for the [{}] property.", task.get(key), key);
+        }
+    }
+}

--- a/application-confluence-migrator-pro-converters/src/main/java/com/xwiki/confluencepro/converters/internal/TaskMacroConverter.java
+++ b/application-confluence-migrator-pro-converters/src/main/java/com/xwiki/confluencepro/converters/internal/TaskMacroConverter.java
@@ -22,12 +22,14 @@ package com.xwiki.confluencepro.converters.internal;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.contrib.confluence.filter.internal.macros.AbstractMacroConverter;
 
+import com.xwiki.task.TaskConfiguration;
 import com.xwiki.task.model.Task;
 
 /**
@@ -48,6 +50,9 @@ public class TaskMacroConverter extends AbstractMacroConverter
     private static final String TASK_REFERENCE_PARAMETER = "reference";
 
     private static final String TASK_REFERENCE_PREFIX = "/Tasks/Task_";
+
+    @Inject
+    private TaskConfiguration taskConfiguration;
 
     @Override
     protected String toXWikiContent(String confluenceId, Map<String, String> parameters, String confluenceContent)
@@ -74,7 +79,7 @@ public class TaskMacroConverter extends AbstractMacroConverter
         String confluenceStatus = confluenceParameters.get(TASK_STATUS_PARAMETER);
         String xwikiStatus = confluenceStatus.equals("complete") || confluenceStatus.equals(Task.STATUS_DONE)
             ? Task.STATUS_DONE
-            : Task.STATUS_IN_PROGRESS;
+            : taskConfiguration.getDefaultInlineStatus();
         String confluenceTaskId = confluenceParameters.get(TASK_ID_PARAMETER);
         String reference = confluenceParameters.get(TASK_REFERENCE_PARAMETER);
         String xwikiIdParam = confluenceTaskId != null

--- a/application-confluence-migrator-pro-converters/src/main/resources/META-INF/components.txt
+++ b/application-confluence-migrator-pro-converters/src/main/resources/META-INF/components.txt
@@ -7,6 +7,7 @@ com.xwiki.confluencepro.converters.internal.MultiExcerptMacroConverter
 com.xwiki.confluencepro.converters.internal.MultiExcerptIncludeMacroConverter
 com.xwiki.confluencepro.converters.internal.TaskMacroConverter
 com.xwiki.confluencepro.converters.internal.TaskListMacroConverter
+com.xwiki.confluencepro.converters.internal.LegacyTaskListMacroConverter
 com.xwiki.confluencepro.converters.internal.TasksReportMacroConverter
 com.xwiki.confluencepro.converters.internal.ProfileMacroConverter
 com.xwiki.confluencepro.converters.internal.ShowIfHideIfMacroConverter

--- a/application-confluence-migrator-pro-converters/src/test/java/com/xwiki/confluencepro/IntegrationTests.java
+++ b/application-confluence-migrator-pro-converters/src/test/java/com/xwiki/confluencepro/IntegrationTests.java
@@ -45,6 +45,7 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.mockito.MockitoComponentManager;
 
 import com.xwiki.date.DateMacroConfiguration;
+import com.xwiki.task.TaskConfiguration;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -70,6 +71,8 @@ public class IntegrationTests
 
         DateMacroConfiguration dateConfig = componentManager.registerMockComponent(DateMacroConfiguration.class);
         when(dateConfig.getStorageDateFormat()).thenReturn("yyyy/MM/dd HH:mm");
+        TaskConfiguration taskConfiguration = componentManager.registerMockComponent(TaskConfiguration.class);
+        when(taskConfiguration.getDefaultInlineStatus()).thenReturn("InProgress");
 
         EntityNameValidationManager validationManager =
             componentManager.registerMockComponent(EntityNameValidationManager.class);

--- a/application-confluence-migrator-pro-converters/src/test/resources/proconverters/tasks.test
+++ b/application-confluence-migrator-pro-converters/src/test/resources/proconverters/tasks.test
@@ -87,6 +87,32 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
 {{/task}}
 )))
 {{/task}}
+)))
+
+(% width="80%" %)
+(((
+**Task list title**
+
+{{task reference="/Tasks/Task_Legacy_0" status="InProgress" createDate="2025/04/14 08:48"}}
+my first task {{mention reference="XWiki.jtille" anchor="XWiki-jtille-legacy-0" style="FULL_NAME"/}}
+{{/task}}
+
+{{task reference="/Tasks/Task_Legacy_1" status="InProgress" createDate="2025/04/14 08:48"}}
+my second task {{mention reference="XWiki.jtille" anchor="XWiki-jtille-legacy-1" style="FULL_NAME"/}}
+{{/task}}
+)))
+
+(% width="80%" %)
+(((
+**Task list title**
+
+{{task reference="/Tasks/Task_Legacy_2" status="InProgress" createDate="2025/04/14 08:48"}}
+my first task2 {{mention reference="XWiki.jtille" anchor="XWiki-jtille-legacy-2" style="FULL_NAME"/}}
+{{/task}}
+
+{{task reference="/Tasks/Task_Legacy_3" status="Done" createDate="2025/04/14 08:48" completeDate="2025/04/25 22:35"}}
+my second task2 {{mention reference="XWiki.jtille" anchor="XWiki-jtille-legacy-3" style="FULL_NAME"/}}
+{{/task}}
 )))</string>
             </entry>
             <entry>

--- a/application-confluence-migrator-pro-converters/src/test/resources/proconverters/tasks/entities.xml
+++ b/application-confluence-migrator-pro-converters/src/test/resources/proconverters/tasks/entities.xml
@@ -92,6 +92,27 @@
     </ac:task-body>
   </ac:task>
 </ac:task-list>
+
+<ac:structured-macro ac:macro-id="3f8c46da-81a6-4e0d-a1a5-b8bd80032c07" ac:name="tasklist" ac:schema-version="1">
+  <ac:parameter ac:name="width">80%</ac:parameter>
+  <ac:parameter ac:name="title">Task list title</ac:parameter>
+  <ac:plain-text-body><![CDATA[||Completed||Priority||Locked||CreatedDate||CompletedDate||Assignee||Name||
+|F|M|F|1744620516591|          |jtille|my first task|
+|F|M|F|1744620525970|          |jtille|my second task|
+]]]]><![CDATA[></ac:plain-text-body>
+</ac:structured-macro>
+
+<ac:structured-macro ac:macro-id="2437bd87-b48a-431f-a2a8-a5c77ae5b95e" ac:name="tasklist" ac:schema-version="1">
+  <ac:parameter ac:name="width">80%</ac:parameter>
+  <ac:parameter ac:name="title">Task list title</ac:parameter>
+  <ac:parameter ac:name="enableLocking">true</ac:parameter>
+  <ac:parameter ac:name="promptOnDelete">true</ac:parameter>
+  <ac:plain-text-body><![CDATA[||Completed||Priority||Locked||CreatedDate||CompletedDate||Assignee||Name||
+|F|M|F|1744620516591|          |jtille|my first task2|
+|T|M|F|1744620525970|1745620525970|jtille|my second task2|
+]]]]><![CDATA[></ac:plain-text-body>
+</ac:structured-macro>
+
 ]]></property>
     <property name="content" class="Page" package="com.atlassian.confluence.pages"><id name="id">45809845</id></property>
     <property name="bodyType">2</property>


### PR DESCRIPTION
Close #317

The confluence syntax that needs conversion is the following
```
<ac:structured-macro ac:macro-id="2437bd87-b48a-431f-a2a8-a5c77ae5b95e" ac:name="tasklist" ac:schema-version="1">
  <ac:parameter ac:name="width">80%</ac:parameter>
  <ac:parameter ac:name="title">Task list title</ac:parameter>
  <ac:parameter ac:name="enableLocking">true</ac:parameter>
  <ac:parameter ac:name="promptOnDelete">true</ac:parameter>
  <ac:plain-text-body><![CDATA[||Completed||Priority||Locked||CreatedDate||CompletedDate||Assignee||Name||
|F|M|F|1744620516591|          |jtille|my first task|
|F|M|F|1744620525970|          |jtille|my second task|
]]></ac:plain-text-body>
</ac:structured-macro>
```

This PR aims to generate the following xwiki syntax:
```
group
boldFormat title
task macro1
task macro2
...
task macroN
group end
```
The tasks are extracted from the content of the confluence macro by manually parsing it.

Screenshot of resulting xwiki syntax:
![image](https://github.com/user-attachments/assets/827911c0-61a7-4922-a7e6-772d7bfa15ad)
