### PR TITLE
#355: Calendar migration - WebPreferences page not correctly configured

### DIFF
--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
@@ -665,7 +665,7 @@ public class CalendarMigratorScriptService implements ScriptService
 
             prefDoc.setHidden(true)
             // Seem that by default XWiki set this page title
-            prefDoc.setTitle("Preferences")
+            prefDoc.setTitle("\$services.localization.render('admin.preferences.title')")
             // Ensure to have a XWiki.XWikiPreferences object in the page
             prefDoc.getXObject(new LocalDocumentReference("XWiki", "XWikiPreferences"), true, context)
             prefDoc.setAuthor(creatorRef)


### PR DESCRIPTION
Fix https://github.com/xwikisas/application-confluence-migrator-pro/issues/355