### PR TITLE
#390: [Meta] Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+# Issue URL
+
+<!-- Add the link to the corresponding issue referenced in a commit message. Unless this is a [Misc] commit,
+see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
+-->
+
+# Changes
+
+## Description
+
+<!-- Describe the main changes brought in this PR. -->
+
+*
+
+## Clarifications
+
+<!-- Provide extra hints to make it easier to understand the PR. Those could be:
+* Explanation of choices made in this PR
+* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
+* Links to other issues this issue depends on
+-->
+
+*
+
+# Screenshots & Video
+
+<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
+or even a screen recording for complex interactions. 
+-->
+
+# Executed Tests
+
+<!-- Especially important for regression fixes. 
+Indicate how changes were tested (e.g., what maven commands were run to validate them).
+-->
+
+* [ ] I checked the accessibility of this change (if you don't know what this is about or how to do it, leave this unchecked and don't worry)
+
+# Expected merging strategy
+
+* Prefers squash: Yes <!-- No — Explain why. -->


### PR DESCRIPTION
# Issue URL

https://github.com/xwikisas/application-confluence-migrator-pro/issues/390

# Changes

## Description

This adds a pull request template on GitHub.

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
