### PR TITLE
Fix Group and calendar import

### DIFF
--- a/application-confluence-migrator-pro-default/src/main/java/com/xwiki/confluencepro/internal/ExtraImportTools.java
+++ b/application-confluence-migrator-pro-default/src/main/java/com/xwiki/confluencepro/internal/ExtraImportTools.java
@@ -1,0 +1,113 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.confluencepro.internal;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.io.input.BOMInputStream;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.util.DefaultParameterizedType;
+import org.xwiki.contrib.confluence.filter.Mapping;
+import org.xwiki.contrib.confluence.filter.input.ConfluenceInputContext;
+import org.xwiki.contrib.confluence.filter.input.ConfluenceInputProperties;
+import org.xwiki.contrib.confluence.filter.internal.input.DefaultConfluenceInputContext;
+import org.xwiki.properties.converter.Converter;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiAttachment;
+
+/**
+ * Tools for calendar and group importer.
+ *
+ * @version $Id$
+ * @since 1.43.4
+ */
+@Component(roles = { ExtraImportTools.class })
+@Singleton
+public class ExtraImportTools
+{
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private ComponentManager componentManager;
+
+    /**
+     * @param userMappingStr the user mapping in string format
+     * @param groupMappingStr the group mapping in string format
+     * @param userFormat the user format to apply
+     * @param groupFormat the group format to apply
+     * @throws ComponentLookupException In case a component can't be found.
+     */
+    public void configureUserGroupMapping(String userMappingStr, String groupMappingStr, String userFormat,
+        String groupFormat)
+        throws ComponentLookupException
+    {
+        var converterMappingType = new DefaultParameterizedType(null, Converter.class, Mapping.class);
+        Converter<Mapping> mappingConverter = componentManager.getInstance(converterMappingType);
+        Mapping userMapping = mappingConverter.convert(Mapping.class, userMappingStr);
+        Mapping groupMapping = mappingConverter.convert(Mapping.class, groupMappingStr);
+
+        ConfluenceInputContext confluenceInputContext = componentManager.getInstance(ConfluenceInputContext.class);
+        var confluenceProperties = new ConfluenceInputProperties();
+        confluenceProperties.setUserIdMapping(userMapping);
+        confluenceProperties.setGroupMapping(groupMapping);
+        confluenceProperties.setUserFormat(userFormat);
+        confluenceProperties.setGroupFormat(groupFormat);
+        ((DefaultConfluenceInputContext) confluenceInputContext).set(null, confluenceProperties);
+    }
+
+    /**
+     * @param attachment the attachment to read
+     * @return an input stream reader from the given attachment, taking care of ignoring, if present, the UTF-8 BOM
+     *     which can cause hard to understand issues, since the Apache Common CSV parser doesn't support it. NOTE:
+     *     Microsoft Excel can generate CSVs with BOM.
+     */
+    public InputStreamReader getInputStreamReader(XWikiAttachment attachment) throws XWikiException, IOException
+    {
+        return new InputStreamReader(
+            BOMInputStream.builder().setInputStream(attachment.getContentInputStream(contextProvider.get())).get());
+    }
+
+    /**
+     * @param isr The InpoutStreamReader used to build the CSV parser.
+     * @return The CSV  parser configured for group and calendar import.
+     * @throws IOException in case something goes wrong with the InputStreamReader.
+     */
+    public static CSVParser getCsvParser(InputStreamReader isr) throws IOException
+    {
+        return CSVFormat.RFC4180.builder().setHeader().setSkipHeaderRecord(true).setTrim(true).setDelimiter(';').build()
+            .parse(isr);
+    }
+}

--- a/application-confluence-migrator-pro-default/src/main/resources/META-INF/components.txt
+++ b/application-confluence-migrator-pro-default/src/main/resources/META-INF/components.txt
@@ -9,5 +9,6 @@ com.xwiki.confluencepro.internal.DefaultConfluenceMigrationPrerequisites
 com.xwiki.confluencepro.internal.DiagramConversionJob
 com.xwiki.confluencepro.internal.DiagramConverter
 com.xwiki.confluencepro.internal.DocumentFilterOverrideListener
+com.xwiki.confluencepro.internal.ExtraImportTools
 com.xwiki.confluencepro.internal.LinkMappingConverter
 com.xwiki.confluencepro.script.ConfluenceDiagramConverterScriptService

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/ConfluenceSQLRequests.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/ConfluenceSQLRequests.xml
@@ -38,7 +38,7 @@
   <hidden>true</hidden>
   <content>== Generality ==
 
-The delimiter of the CSV file is expected to be {{code}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. The line return must be in Unix format so {{code}}\n{{/code}}. In Linux you can if needed convert the file with {{code}}dos2unix{{/code}}.
+The delimiter of the CSV file is expected to be {{code}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. It's recommended to have the line return in Unix format so {{code}}\n{{/code}}. In Linux you can if needed to convert the file with {{code}}dos2unix{{/code}}.
 
 All dates are expected to be provided in milliseconds since the Epoch of 1970-01-01T00:00:00Z. So by example {{code}}1747062480020{{/code}} will mean {{code}}Mon May 12 15:08:00 UTC 2025{{/code}}. Note it's the date format used in Java when we create a date with {{code language="java"}}new Date(&lt;value&gt;){{/code}}
 

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/ConfluenceSQLRequests.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/ConfluenceSQLRequests.xml
@@ -38,7 +38,7 @@
   <hidden>true</hidden>
   <content>== Generality ==
 
-The delimiter of the CSV file is expected to be {{code}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. It's recommended to have the line return in Unix format so {{code}}\n{{/code}}. In Linux you can if needed to convert the file with {{code}}dos2unix{{/code}}.
+The delimiter of the CSV file is expected to be {{code language="none"}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. It's recommended to have the line return in Unix format (LF: {{code language="none"}}\n{{/code}}). You can convert files in dos format (CRLF, {{code language="none"}}\r\n{{/code}})  with tools like {{code}}dos2unix{{/code}} on Linux.
 
 All dates are expected to be provided in milliseconds since the Epoch of 1970-01-01T00:00:00Z. So by example {{code}}1747062480020{{/code}} will mean {{code}}Mon May 12 15:08:00 UTC 2025{{/code}}. Note it's the date format used in Java when we create a date with {{code language="java"}}new Date(&lt;value&gt;){{/code}}
 

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
@@ -203,7 +203,7 @@ import org.xwiki.properties.converter.Converter
 final String documentName = "ConfluenceMigratorPro.CalendarMigration.WebHome"
 
 def logger = services.logging.getLogger(documentName);
-services.logging.setLevel(doc.fullName, LogLevel.DEBUG)
+services.logging.setLevel(doc.fullName, LogLevel.INFO)
 
 try {
     if (!services.csrf.isTokenValid(request.get("form_token"))) {

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
@@ -374,12 +374,12 @@ import com.xpn.xwiki.objects.LargeStringProperty
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser
 import org.apache.commons.csv.CSVRecord
+import org.apache.commons.io.input.BOMInputStream
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.time.DateUtils
 import org.slf4j.Logger
 import org.xwiki.component.annotation.Component
 import org.xwiki.contrib.confluence.filter.ConfluenceFilterReferenceConverter
-import org.xwiki.contrib.confluence.filter.Mapping
 import org.xwiki.contrib.confluence.resolvers.ConfluenceSpaceKeyResolver
 import org.xwiki.job.script.ProgressScripService
 import org.xwiki.localization.LocalizationManager
@@ -540,7 +540,7 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Number of parents [{}], number of sub-calendars [{}]", parents.size(), subCalendarNumber)
         logger.info("Creating parent calendars")
 
-        InputStreamReader isr = new InputStreamReader(attachments['parentCalendars'].getContentInputStream())
+        InputStreamReader isr = getInputStreamReader(attachments['parentCalendars'])
         getCsvParser(isr).each { entry -&gt;
             def calendarId = entry.get("ID")
             ParentCalendar parentCalendar = parents.find { it.confluenceId() == calendarId }
@@ -683,7 +683,7 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Creating parent calendars done")
         logger.info("Creating sub-calendars")
 
-        isr = new InputStreamReader(attachments['subCalendars'].getContentInputStream())
+        isr = getInputStreamReader(attachments['subCalendars'])
         getCsvParser(isr).each { entry -&gt;
             ParentCalendar parent = parents.find { it.confluenceId() == entry.get("PARENT_ID") }
             if (parent == null) {
@@ -757,8 +757,7 @@ public class CalendarMigratorScriptService implements ScriptService
         Set&lt;String&gt; ignoredEventByVUID = loadEv.ignoredEventByVUID()
         List&lt;SubCalendar&gt; allCalendars = parents.collectMany { it.subCalendars() }
 
-        InputStream is = eventsAttachments['eventExclusion'].getContentInputStream()
-        InputStreamReader isr = new InputStreamReader(is)
+        InputStreamReader isr = getInputStreamReader(eventsAttachments['eventExclusion'])
         int lineCount = 0
         isr.eachLine { it -&gt; lineCount++ }
         isr.close()
@@ -800,7 +799,7 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Creating events")
 
-        isr = new InputStreamReader(eventsAttachments['events'].getContentInputStream())
+        isr = getInputStreamReader(eventsAttachments['events'])
         int counter = 1
         getCsvParser(isr).each { entry -&gt;
             if (StringUtils.isNotEmpty(entry.get("RECURRENCE_ID_TIMESTAMP"))) {
@@ -953,7 +952,7 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Loading events override data")
 
         Map&lt;String, List&lt;Map&lt;String, String&gt;&gt;&gt; eventOverrides = [:]
-        isr = new InputStreamReader(eventsAttachments['events'].getContentInputStream())
+        isr = getInputStreamReader(eventsAttachments['events'])
         getCsvParser(isr).each { entry -&gt;
             if (StringUtils.isEmpty(entry.get("RECURRENCE_ID_TIMESTAMP"))) {
                 // When 'RECURRENCE_ID_TIMESTAMP' is not set, it's a "normal" event, ignoring it here
@@ -1021,7 +1020,7 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Loading events exclusion data")
 
         Map&lt;String, List&lt;String&gt;&gt; eventExclusion = [:]
-        isr = new InputStreamReader(eventsAttachments['eventExclusion'].getContentInputStream())
+        isr = getInputStreamReader(eventsAttachments['eventExclusion'])
         getCsvParser(isr).each { entry -&gt;
             String eventId = entry.get("EVENT_ID")
             if (ignoredEvents.contains(eventId)) {
@@ -1295,7 +1294,7 @@ public class CalendarMigratorScriptService implements ScriptService
         Set&lt;String&gt; ignoredSubCalendars = new HashSet&lt;&gt;()
 
         logger.info("Load calendar space mapping")
-        InputStreamReader isr = new InputStreamReader(spaceMapping.getContentInputStream())
+        InputStreamReader isr = getInputStreamReader(spaceMapping)
         getCsvParser(isr).each { entry -&gt;
             String spaceKey = entry.get("SPACE_KEY")
             String id = entry.get("SUB_CALENDAR_ID")
@@ -1309,7 +1308,7 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Load parents calendars")
 
-        isr = new InputStreamReader(parents.getContentInputStream())
+        isr = getInputStreamReader(parents)
         getCsvParser(isr).each { entry -&gt;
             String spaceKey = entry.get("SPACE_KEY")
             String name = entry.get("NAME")
@@ -1405,7 +1404,7 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Load sub calendars")
 
-        isr = new InputStreamReader(children.getContentInputStream())
+        isr = getInputStreamReader(children)
         getCsvParser(isr).each { entry -&gt;
             String id = entry.get("ID")
             logger.debug("Loading sub calendar ID [{}]", id)
@@ -1448,7 +1447,7 @@ public class CalendarMigratorScriptService implements ScriptService
         Map&lt;String, Map&lt;String, HashSet&lt;String&gt;&gt;&gt; result = [:]
 
         logger.info("Load group rights")
-        InputStreamReader isr = new InputStreamReader(groupRigths.getContentInputStream())
+        InputStreamReader isr = getInputStreamReader(groupRigths)
         getCsvParser(isr).each { entry -&gt;
             String calendarId = entry.get("SUB_CALENDAR_ID")
             String groupName = entry.get("GROUP_NAME")
@@ -1472,7 +1471,7 @@ public class CalendarMigratorScriptService implements ScriptService
         Map&lt;String, Map&lt;String, HashSet&lt;String&gt;&gt;&gt; result = [:]
 
         logger.info("Load user rights")
-        InputStreamReader isr = new InputStreamReader(userRights.getContentInputStream())
+        InputStreamReader isr = getInputStreamReader(userRights)
         getCsvParser(isr).each { entry -&gt;
             String calendarId = entry.get("SUB_CALENDAR_ID")
             String userName = entry.get("username")
@@ -1505,7 +1504,7 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Load events invitees")
 
-        InputStreamReader isr = new InputStreamReader(invitees.getContentInputStream())
+        InputStreamReader isr = getInputStreamReader(invitees)
         getCsvParser(isr).each { entry -&gt;
             String eventId = entry.get("EVENT_ID")
             logger.debug("Loading event invitee ID [{}]", eventId)
@@ -1524,7 +1523,7 @@ public class CalendarMigratorScriptService implements ScriptService
         Map&lt;String, SubCalendar&gt; subCalendarsByIds =
             loadCalendarResult.result().collectMany { it.subCalendars() }.collectEntries { [it.confluenceId(), it] }
 
-        isr = new InputStreamReader(events.getContentInputStream())
+        isr = getInputStreamReader(events)
         getCsvParser(isr).each { entry -&gt;
             String name = entry.get("SUMMARY")
             String id = entry.get("ID")
@@ -1605,6 +1604,18 @@ public class CalendarMigratorScriptService implements ScriptService
         // converted to a date that we can store in XWiki
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
         return sdf
+    }
+    /**
+     * Get InputStreamReader from attachment and also take care of wrapping it into a BOMInputStream to avoid any issue
+     * in case of the input file contains BOM header. Note that the apache common parser don't support BOM header and
+     * and raise strange issue in case of BOM headers. Note that microsoft except can generate CSV with BOM.
+     *
+     * @param attachment
+     * @return
+     */
+    protected static InputStreamReader getInputStreamReader(Attachment attachment)
+    {
+        return new InputStreamReader(BOMInputStream.builder().setInputStream(attachment.getContentInputStream()).get())
     }
 
     protected static CSVParser getCsvParser(InputStreamReader isr)

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
@@ -89,7 +89,7 @@ See [[the SQL requests to perform on the Confluence database&gt;&gt;ConfluenceMi
         &lt;span class="xHint"&gt;Name of the attachment from which to read data to import calendar pages&lt;/span&gt;
       &lt;/dt&gt;
       &lt;dd&gt;
-        &lt;input type="text" id="${i.key}Filename" name="${i.key}Filename" value="$!escapetool.xml($!request.get("${i.key}FileName"))" placeholder='${i.key}.csv'/&gt;
+        &lt;input type="text" id="${i.key}Filename" name="${i.key}Filename" value="$!escapetool.xml($!request.get("${i.key}Filename"))" placeholder='${i.key}.csv'/&gt;
       &lt;/dd&gt;
     #end
     &lt;dt&gt;
@@ -220,7 +220,7 @@ try {
     List&lt;String&gt; spaceFilter = null
 
     for (String i in calendarsFieldsMap.keySet()) {
-        def filename = request.get(i)
+        def filename = request.get("${i}Filename")
         if (StringUtils.isEmpty(filename)) {
             filename = "${i}.csv"
         }
@@ -234,7 +234,7 @@ try {
     }
     if (request.importType == "events") {
         for (String i in eventsFieldsMap.keySet()) {
-            def filename = request.get(i)
+            def filename = request.get("${i}Filename")
             if (StringUtils.isEmpty(filename)) {
                 filename = "${i}.csv"
             }

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/CalendarMigration/WebHome.xml
@@ -188,17 +188,11 @@ See [[the SQL requests to perform on the Confluence database&gt;&gt;ConfluenceMi
 
 {{job id="{{velocity}}${request.jobId}{{/velocity}}" start="{{velocity}}${request.confirm}{{/velocity}}"}}
 {{groovy}}
+import com.xwiki.confluencepro.internal.ExtraImportTools
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
-
 import org.apache.commons.lang3.StringUtils
-import org.xwiki.component.util.DefaultParameterizedType
-import org.xwiki.contrib.confluence.filter.Mapping
-import org.xwiki.contrib.confluence.filter.input.ConfluenceInputContext
-import org.xwiki.contrib.confluence.filter.input.ConfluenceInputProperties
-import org.xwiki.contrib.confluence.filter.internal.input.DefaultConfluenceInputContext
 import org.xwiki.logging.LogLevel
-import org.xwiki.properties.converter.Converter
 
 final String documentName = "ConfluenceMigratorPro.CalendarMigration.WebHome"
 
@@ -259,21 +253,10 @@ try {
         start = new Date();
 
         // Parameter the confluence context so the user and group mapping are handled in a correct way
-        def converterMappingType = new DefaultParameterizedType(null, Converter.class, Mapping.class);
-        Converter mappingConverter = services.component.getInstance(converterMappingType)
-        def userMapping = mappingConverter.&lt;Mapping&gt; convert(Mapping.class, request.get('userMapping') ?: '')
-        def groupMapping = mappingConverter.&lt;Mapping&gt; convert(Mapping.class, request.get('groupMapping') ?: '')
-
-        ConfluenceInputContext confluenceInputContext = services.component.getInstance(ConfluenceInputContext.class)
-        def confluenceProperties = new ConfluenceInputProperties() {
-            {
-                setUserIdMapping(userMapping)
-                setGroupMapping(groupMapping)
-                setUserFormat(request.get('userFormat'))
-                setGroupFormat(request.get('groupFormat'))
-            }
-        }
-        (confluenceInputContext as DefaultConfluenceInputContext).set(null, confluenceProperties)
+        ExtraImportTools extraImportTools = services.component.getInstance(ExtraImportTools.class)
+        extraImportTools.configureUserGroupMapping(
+            request.get('userMapping') ?: '', request.get('groupMapping') ?: '',
+            request.get('userFormat'), request.get('groupFormat'))
 
         if (request.importType == "calendars") {
             services.calendarmigrator.migrateCalendars(services.progress, calendarsAttachements, dontCleanRights,
@@ -371,10 +354,9 @@ import com.xpn.xwiki.api.Attachment
 import com.xpn.xwiki.doc.XWikiDocument
 import com.xpn.xwiki.objects.BaseObject
 import com.xpn.xwiki.objects.LargeStringProperty
-import org.apache.commons.csv.CSVFormat
+import com.xwiki.confluencepro.internal.ExtraImportTools
 import org.apache.commons.csv.CSVParser
 import org.apache.commons.csv.CSVRecord
-import org.apache.commons.io.input.BOMInputStream
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.time.DateUtils
 import org.slf4j.Logger
@@ -520,6 +502,9 @@ public class CalendarMigratorScriptService implements ScriptService
     @Inject
     private ConfluenceFilterReferenceConverter confluenceConverter;
 
+    @Inject
+    private ExtraImportTools extraImportTools
+
     void migrateCalendars(ProgressScripService progress, Map&lt;String, Attachment&gt; attachments, boolean dontCleanRights,
         boolean dryRun, List&lt;String&gt; spaceFilter)
     {
@@ -540,8 +525,8 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Number of parents [{}], number of sub-calendars [{}]", parents.size(), subCalendarNumber)
         logger.info("Creating parent calendars")
 
-        InputStreamReader isr = getInputStreamReader(attachments['parentCalendars'])
-        getCsvParser(isr).each { entry -&gt;
+        InputStreamReader isr = extraImportTools.getInputStreamReader(attachments['parentCalendars'].attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             def calendarId = entry.get("ID")
             ParentCalendar parentCalendar = parents.find { it.confluenceId() == calendarId }
             if (parentCalendar == null) {
@@ -683,8 +668,8 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Creating parent calendars done")
         logger.info("Creating sub-calendars")
 
-        isr = getInputStreamReader(attachments['subCalendars'])
-        getCsvParser(isr).each { entry -&gt;
+        isr = extraImportTools.getInputStreamReader(attachments['subCalendars'].attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             ParentCalendar parent = parents.find { it.confluenceId() == entry.get("PARENT_ID") }
             if (parent == null) {
                 if (!ignoredParentCalendars.contains(entry.get("PARENT_ID"))) {
@@ -757,7 +742,7 @@ public class CalendarMigratorScriptService implements ScriptService
         Set&lt;String&gt; ignoredEventByVUID = loadEv.ignoredEventByVUID()
         List&lt;SubCalendar&gt; allCalendars = parents.collectMany { it.subCalendars() }
 
-        InputStreamReader isr = getInputStreamReader(eventsAttachments['eventExclusion'])
+        InputStreamReader isr = extraImportTools.getInputStreamReader(eventsAttachments['eventExclusion'].attachment)
         int lineCount = 0
         isr.eachLine { it -&gt; lineCount++ }
         isr.close()
@@ -799,9 +784,9 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Creating events")
 
-        isr = getInputStreamReader(eventsAttachments['events'])
+        isr = extraImportTools.getInputStreamReader(eventsAttachments['events'].attachment)
         int counter = 1
-        getCsvParser(isr).each { entry -&gt;
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             if (StringUtils.isNotEmpty(entry.get("RECURRENCE_ID_TIMESTAMP"))) {
                 // When 'RECURRENCE_ID_TIMESTAMP' is set, it's an event override, ignoring it here
                 return
@@ -952,8 +937,8 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Loading events override data")
 
         Map&lt;String, List&lt;Map&lt;String, String&gt;&gt;&gt; eventOverrides = [:]
-        isr = getInputStreamReader(eventsAttachments['events'])
-        getCsvParser(isr).each { entry -&gt;
+        isr = extraImportTools.getInputStreamReader(eventsAttachments['events'].attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             if (StringUtils.isEmpty(entry.get("RECURRENCE_ID_TIMESTAMP"))) {
                 // When 'RECURRENCE_ID_TIMESTAMP' is not set, it's a "normal" event, ignoring it here
                 return
@@ -1020,8 +1005,8 @@ public class CalendarMigratorScriptService implements ScriptService
         logger.info("Loading events exclusion data")
 
         Map&lt;String, List&lt;String&gt;&gt; eventExclusion = [:]
-        isr = getInputStreamReader(eventsAttachments['eventExclusion'])
-        getCsvParser(isr).each { entry -&gt;
+        isr = extraImportTools.getInputStreamReader(eventsAttachments['eventExclusion'].attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String eventId = entry.get("EVENT_ID")
             if (ignoredEvents.contains(eventId)) {
                 return
@@ -1294,8 +1279,8 @@ public class CalendarMigratorScriptService implements ScriptService
         Set&lt;String&gt; ignoredSubCalendars = new HashSet&lt;&gt;()
 
         logger.info("Load calendar space mapping")
-        InputStreamReader isr = getInputStreamReader(spaceMapping)
-        getCsvParser(isr).each { entry -&gt;
+        InputStreamReader isr = extraImportTools.getInputStreamReader(spaceMapping.attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String spaceKey = entry.get("SPACE_KEY")
             String id = entry.get("SUB_CALENDAR_ID")
             List&lt;String&gt; spaces = calendarSpaceMapping.get(id)
@@ -1308,8 +1293,8 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Load parents calendars")
 
-        isr = getInputStreamReader(parents)
-        getCsvParser(isr).each { entry -&gt;
+        isr = extraImportTools.getInputStreamReader(parents.attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String spaceKey = entry.get("SPACE_KEY")
             String name = entry.get("NAME")
             String id = entry.get("ID")
@@ -1404,8 +1389,8 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Load sub calendars")
 
-        isr = getInputStreamReader(children)
-        getCsvParser(isr).each { entry -&gt;
+        isr = extraImportTools.getInputStreamReader(children.attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String id = entry.get("ID")
             logger.debug("Loading sub calendar ID [{}]", id)
 
@@ -1447,8 +1432,8 @@ public class CalendarMigratorScriptService implements ScriptService
         Map&lt;String, Map&lt;String, HashSet&lt;String&gt;&gt;&gt; result = [:]
 
         logger.info("Load group rights")
-        InputStreamReader isr = getInputStreamReader(groupRigths)
-        getCsvParser(isr).each { entry -&gt;
+        InputStreamReader isr = extraImportTools.getInputStreamReader(groupRigths.attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String calendarId = entry.get("SUB_CALENDAR_ID")
             String groupName = entry.get("GROUP_NAME")
             String right = entry.get("TYPE")
@@ -1471,8 +1456,8 @@ public class CalendarMigratorScriptService implements ScriptService
         Map&lt;String, Map&lt;String, HashSet&lt;String&gt;&gt;&gt; result = [:]
 
         logger.info("Load user rights")
-        InputStreamReader isr = getInputStreamReader(userRights)
-        getCsvParser(isr).each { entry -&gt;
+        InputStreamReader isr = extraImportTools.getInputStreamReader(userRights.attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String calendarId = entry.get("SUB_CALENDAR_ID")
             String userName = entry.get("username")
             String right = entry.get("TYPE")
@@ -1504,8 +1489,8 @@ public class CalendarMigratorScriptService implements ScriptService
 
         logger.info("Load events invitees")
 
-        InputStreamReader isr = getInputStreamReader(invitees)
-        getCsvParser(isr).each { entry -&gt;
+        InputStreamReader isr = extraImportTools.getInputStreamReader(invitees.attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String eventId = entry.get("EVENT_ID")
             logger.debug("Loading event invitee ID [{}]", eventId)
             def refList = inviteeMap[eventId]
@@ -1523,8 +1508,8 @@ public class CalendarMigratorScriptService implements ScriptService
         Map&lt;String, SubCalendar&gt; subCalendarsByIds =
             loadCalendarResult.result().collectMany { it.subCalendars() }.collectEntries { [it.confluenceId(), it] }
 
-        isr = getInputStreamReader(events)
-        getCsvParser(isr).each { entry -&gt;
+        isr = extraImportTools.getInputStreamReader(events.attachment)
+        extraImportTools.getCsvParser(isr).each { entry -&gt;
             String name = entry.get("SUMMARY")
             String id = entry.get("ID")
             String vuid = entry.get("VEVENT_UID")
@@ -1606,24 +1591,10 @@ public class CalendarMigratorScriptService implements ScriptService
         return sdf
     }
     /**
-     * Get InputStreamReader from attachment and also take care of wrapping it into a BOMInputStream to avoid any issue
-     * in case of the input file contains BOM header. Note that the apache common parser don't support BOM header and
-     * and raise strange issue in case of BOM headers. Note that microsoft except can generate CSV with BOM.
-     *
-     * @param attachment
-     * @return
+     * @param attachment the attachment to read
+     * @return an input stream reader from the given attachment, taking care of ignoring, if present, the UTF-8 BOM which can cause hard to understand issues, since the Apache Common CSV parser doesn't support it.
+     * NOTE: Microsoft Excel can generate CSVs with BOM.
      */
-    protected static InputStreamReader getInputStreamReader(Attachment attachment)
-    {
-        return new InputStreamReader(BOMInputStream.builder().setInputStream(attachment.getContentInputStream()).get())
-    }
-
-    protected static CSVParser getCsvParser(InputStreamReader isr)
-    {
-        return CSVFormat.RFC4180.builder().setHeader().setSkipHeaderRecord(true).setTrim(true).setDelimiter(';')
-            .build().parse(isr)
-    }
-
     private String normalizeNameForReference(String name)
     {
         String r = entityNameValidationManagerProvider.get().getEntityReferenceNameStrategy().transform(name);

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/ConfluenceSQLRequests.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/ConfluenceSQLRequests.xml
@@ -38,7 +38,7 @@
   <hidden>true</hidden>
   <content>== Generality ==
 
-The delimiter of the CSV file is expected to be {{code}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. The line return must be in Unix format so {{code}}\n{{/code}}. In Linux you can if needed to convert the file with {{code}}dos2unix{{/code}}.
+The delimiter of the CSV file is expected to be {{code}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. It's recommended to have the line return in Unix format so {{code}}\n{{/code}}. In Linux you can if needed to convert the file with {{code}}dos2unix{{/code}}.
 
 All {{code}}NULL{{/code}} value are expected to be just an empty field so for example if the column is empty we will have something like {{code}};value;;{{/code}} when the second column is null or empty. Some database exports could sometime set explicitly {{code}}NULL{{/code}} in the CSV export, in this case this must be fixed before being imported in XWiki.
 

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/ConfluenceSQLRequests.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/ConfluenceSQLRequests.xml
@@ -38,7 +38,7 @@
   <hidden>true</hidden>
   <content>== Generality ==
 
-The delimiter of the CSV file is expected to be {{code}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. It's recommended to have the line return in Unix format so {{code}}\n{{/code}}. In Linux you can if needed to convert the file with {{code}}dos2unix{{/code}}.
+The delimiter of the CSV file is expected to be {{code language="none"}};{{/code}} and the first line of the CSV is expected to be the header with the title of each column. It's recommended to have the line return in Unix format (LF: {{code language="none"}}\n{{/code}}). You can convert files in dos format (CRLF, {{code language="none"}}\r\n{{/code}})  with tools like {{code}}dos2unix{{/code}} on Linux.
 
 All {{code}}NULL{{/code}} value are expected to be just an empty field so for example if the column is empty we will have something like {{code}};value;;{{/code}} when the second column is null or empty. Some database exports could sometime set explicitly {{code}}NULL{{/code}} in the CSV export, in this case this must be fixed before being imported in XWiki.
 

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
@@ -154,17 +154,11 @@ See [[the SQL requests to perform on the Confluence database&gt;&gt;ConfluenceMi
 
 {{job id="{{velocity~}~}${request.jobId}{{/velocity~}~}" start="{{velocity~}~}${request.confirm}{{/velocity~}~}" grouppath="GroupsImporter"}}
 {{groovy}}
+import com.xwiki.confluencepro.internal.ExtraImportTools
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
-
 import org.apache.commons.lang3.StringUtils
-import org.xwiki.component.util.DefaultParameterizedType
-import org.xwiki.contrib.confluence.filter.Mapping
-import org.xwiki.contrib.confluence.filter.input.ConfluenceInputContext
-import org.xwiki.contrib.confluence.filter.input.ConfluenceInputProperties
-import org.xwiki.contrib.confluence.filter.internal.input.DefaultConfluenceInputContext
 import org.xwiki.logging.LogLevel
-import org.xwiki.properties.converter.Converter
 
 logger = services.logging.getLogger(doc.fullName);
 services.logging.setLevel(doc.fullName, LogLevel.INFO);
@@ -197,21 +191,10 @@ try {
         def start = new Date();
 
         // Parameter the confluence context so the user and group mapping are handled in a correct way
-        def converterMappingType = new DefaultParameterizedType(null, Converter.class, Mapping.class);
-        Converter mappingConverter = services.component.getInstance(converterMappingType)
-        def userMapping = mappingConverter.&lt;Mapping&gt; convert(Mapping.class, request.get('userMapping') ?: '')
-        def groupMapping = mappingConverter.&lt;Mapping&gt; convert(Mapping.class, request.get('groupMapping') ?: '')
-
-        ConfluenceInputContext confluenceInputContext = services.component.getInstance(ConfluenceInputContext.class)
-        def confluenceProperties = new ConfluenceInputProperties() {
-            {
-                setUserIdMapping(userMapping)
-                setGroupMapping(groupMapping)
-                setUserFormat(request.get('userFormat'))
-                setGroupFormat(request.get('groupFormat'))
-            }
-        }
-        (confluenceInputContext as DefaultConfluenceInputContext).set(null, confluenceProperties)
+        ExtraImportTools extraImportTools = services.component.getInstance(ExtraImportTools.class)
+        extraImportTools.configureUserGroupMapping(
+            request.get('userMapping') ?: '', request.get('groupMapping') ?: '',
+            request.get('userFormat'), request.get('groupFormat'))
 
         def processAdmin = request.processadmin == 'on'
         def cleangroups = request.cleangroups == 'on'
@@ -300,10 +283,9 @@ try {
 import com.xpn.xwiki.XWiki
 import com.xpn.xwiki.XWikiContext
 import com.xpn.xwiki.doc.XWikiAttachment
-import org.apache.commons.csv.CSVFormat
+import com.xwiki.confluencepro.internal.ExtraImportTools
 import org.apache.commons.csv.CSVParser
 import org.apache.commons.csv.CSVRecord
-import org.apache.commons.io.input.BOMInputStream
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.Logger
 import org.xwiki.component.annotation.Component
@@ -339,6 +321,9 @@ public class GroupMigratorScriptService implements ScriptService
 
     @Inject
     private ConfluenceFilterReferenceConverter confluenceConverter;
+
+    @Inject
+    private ExtraImportTools extraImportTools
 
     @Inject
     private Logger logger
@@ -383,16 +368,8 @@ public class GroupMigratorScriptService implements ScriptService
             logger.info("Processed [{}] groups with users", groupsWithUsers ? groupsWithUsers.size() : 0)
 
             // 3. read the list of groups to migrate and prepare the full list of groups to create (including child groups)
-            // Take care of wrapping it into a BOMInputStream to avoid any issue
-            // in case of the input file contains BOM header. Note that the apache common parser don't support BOM header and
-            // and raise strange issue in case of BOM headers. Note that microsoft except can generate CSV with BOM.
-            InputStream is =
-                BOMInputStream.builder().setInputStream(groupsToMigrateFile.getContentInputStream(context)).get()
-            InputStreamReader isr = new InputStreamReader(is);
-            CSVParser parser = CSVFormat.RFC4180.builder()
-                .setHeader().setSkipHeaderRecord(true).setTrim(true).setDelimiter(';')
-                .build()
-                .parse(isr)
+            InputStreamReader isr = extraImportTools.getInputStreamReader(groupsToMigrateFile)
+            CSVParser parser = extraImportTools.getCsvParser(isr)
 
             List&lt;String&gt; groupsToMigrateFirstLevel = [];
             parser.each { record -&gt;
@@ -479,7 +456,7 @@ public class GroupMigratorScriptService implements ScriptService
             }
             progress.popLevel();
         } catch (Exception e) {
-            logger.error("Failed to load or process mapping from CSV: ", e);
+            logger.error("Failed to load or process mapping from CSV", e);
         }
     }
     /**
@@ -500,16 +477,8 @@ public class GroupMigratorScriptService implements ScriptService
     {
         Map&lt;String, List&lt;String&gt;&gt; result = new TreeMap&lt;String, List&lt;String&gt;&gt;();
 
-        // Take care of wrapping it into a BOMInputStream to avoid any issue
-        // in case of the input file contains BOM header. Note that the apache common parser don't support BOM header and
-        // and raise strange issue in case of BOM headers. Note that microsoft except can generate CSV with BOM.
-        InputStream is =
-            BOMInputStream.builder().setInputStream(pairsFile.getContentInputStream(contextProvider.get())).get()
-        InputStreamReader isr = new InputStreamReader(is);
-        CSVParser parser = CSVFormat.RFC4180.builder()
-            .setHeader().setSkipHeaderRecord(true).setTrim(true).setDelimiter(';')
-            .build()
-            .parse(isr);
+        InputStreamReader isr = extraImportTools.getInputStreamReader(pairsFile)
+        CSVParser parser = extraImportTools.getCsvParser(isr)
         for (CSVRecord record : parser) {
             def currentItem = record.get(isSubGroup ? 'groupname' : 'username');
             def currentGroup = record.get(isSubGroup ? 'parentgroupname' : 'groupname');

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
@@ -356,17 +356,24 @@ public class GroupMigratorScriptService implements ScriptService
         def usersInGroupsFile = groupImporterDoc.getAttachment(usersInGroupsFilename)
         def groupsToMigrateFile = groupImporterDoc.getAttachment(groupToMigrateFilename)
 
-        if (groupsInGroupsFile != null &amp;&amp; usersInGroupsFile != null &amp;&amp; groupsToMigrateFile != null) {
-            try {
-                // 1. prepare groups data from the groupsInGroups file
-                def groupsWithGroups = makeListMapFromPairsFile(groupsInGroupsFile, true)
+        if (groupsInGroupsFile == null) {
+            throw new Exception("Can't load file ${groupsInGroupsFilename} in document ${sourcePageRef}")
+        }
+        if (usersInGroupsFile == null) {
+            throw new Exception("Can't load file ${usersInGroupsFilename} in document ${sourcePageRef}")
+        }
+        if (groupsToMigrateFile == null) {
+            throw new Exception("Can't load file ${groupToMigrateFilename} in document ${sourcePageRef}")
+        }
 
-                logger.info("Processed [{}] groups with subgroups", groupsWithGroups ? groupsWithGroups.size() : 0)
+        try {
+            // 1. prepare groups data from the groupsInGroups file
+            def groupsWithGroups = makeListMapFromPairsFile(groupsInGroupsFile, true)
 
-                // 2. prepare users data from usersInGroups file
-                def groupsWithUsers = makeListMapFromPairsFile(usersInGroupsFile, false)
+            logger.info("Processed [{}] groups with subgroups", groupsWithGroups ? groupsWithGroups.size() : 0)
 
-                logger.info("Processed [{}] groups with users", groupsWithUsers ? groupsWithUsers.size() : 0)
+            // 2. prepare users data from usersInGroups file
+            def groupsWithUsers = makeListMapFromPairsFile(usersInGroupsFile, false)
 
             logger.info("Processed [{}] groups with users", groupsWithUsers ? groupsWithUsers.size() : 0)
 
@@ -382,90 +389,92 @@ public class GroupMigratorScriptService implements ScriptService
                 .build()
                 .parse(isr)
 
-                Set&lt;String&gt; allGroupsToMigrateSet = new LinkedHashSet&lt;&gt;();
-                groupsToMigrateFirstLevel.each { traverse(it, groupsWithGroups, allGroupsToMigrateSet) };
-                List&lt;String&gt; allGroupsToMigrate = allGroupsToMigrateSet as List;
+            List&lt;String&gt; groupsToMigrateFirstLevel = [];
+            parser.each { record -&gt;
+                groupsToMigrateFirstLevel &lt;&lt; confluenceConverter.toGroupReferenceName(record.get(0));
+            }
+            isr.close()
 
-                logger.info("Read [{}] groups, importing...", allGroupsToMigrate.size());
+            Set&lt;String&gt; allGroupsToMigrateSet = new LinkedHashSet&lt;&gt;();
+            groupsToMigrateFirstLevel.each { traverse(it, groupsWithGroups, allGroupsToMigrateSet) };
+            List&lt;String&gt; allGroupsToMigrate = allGroupsToMigrateSet as List;
 
-                // start processing
-                progress.pushLevel(allGroupsToMigrate.size());
-                for (def g : allGroupsToMigrate) {
-                    progress.startStep();
+            logger.info("Read [{}] groups, importing...", allGroupsToMigrate.size());
 
-                    // compute group reference
-                    DocumentReference groupReference = new DocumentReference(g, XWIKI_SPACE);
-                    // check if it's admin without admin processing enabled
-                    if (groupReference.getName() == 'XWikiAdminGroup' &amp;&amp; !processAdmin) {
-                        logger.info("Skipping group [{}] as it's not scheduled for processing", groupReference, g);
+            // start processing
+            progress.pushLevel(allGroupsToMigrate.size());
+            for (def g : allGroupsToMigrate) {
+                progress.startStep();
+
+                // compute group reference
+                DocumentReference groupReference = new DocumentReference(g, XWIKI_SPACE);
+                // check if it's admin without admin processing enabled
+                if (groupReference.getName() == 'XWikiAdminGroup' &amp;&amp; !processAdmin) {
+                    logger.info("Skipping group [{}] as it's not scheduled for processing", groupReference, g);
+                    continue;
+                }
+
+                // get unified list of users and groups, since they're added the same way
+                def childrenOfGroup = ((groupsWithGroups.get(g) ?: []) + (groupsWithUsers.get(g) ?: [])).unique();
+
+                logger.info("Importing group [{}] with children (users or groups) [{}]", g, childrenOfGroup);
+
+                boolean wasCleaned = false
+                def groupDoc = xwiki.getDocument(groupReference, context).clone()
+                def groupNeedsSave = false;
+                if (!groupDoc.isNew() &amp;&amp; cleanGroups) {
+                    logger.warn("Cleaning group [{}]", groupReference);
+                    groupDoc.removeXObjects(GROUP_CLASS)
+                    xwiki.saveDocument(groupDoc, "Cleaning the group upon group import", context)
+                    wasCleaned = true;
+                    // reload group doc from the database, to reset object numbers
+                    groupDoc = xwiki.getDocument(groupReference, context).clone();
+                }
+                if (wasCleaned || groupDoc.isNew()) {
+                    // initialize group with a first empty object
+                    def emptyObj = groupDoc.newXObject(GROUP_CLASS, context);
+                    emptyObj.set(GROUP_PROP, "", context);
+                    // set group as hidden, just in case it was not
+                    groupDoc.setHidden(true);
+                    groupNeedsSave = true;
+                }
+                // fill in all users and subgroups, if they're not already in the group
+                for (def c : childrenOfGroup) {
+                    DocumentReference childToAddReference = new DocumentReference(c, XWIKI_SPACE);
+                    String serializedChildToAddReferenceLocal =
+                        serializer.serialize(childToAddReference, "local", groupReference);
+                    def existingMemberObj =
+                        groupDoc.getXObject(GROUP_CLASS, GROUP_PROP, serializedChildToAddReferenceLocal, false)
+                    // try with full reference if compact was not found
+                    if (existingMemberObj == null) {
+                        String serializedChildToAddReferenceFull =
+                            serializer.serialize(childToAddReference, "default")
+                        existingMemberObj =
+                            groupDoc.getXObject(GROUP_CLASS, GROUP_PROP, serializedChildToAddReferenceFull, false)
+                    }
+                    if (existingMemberObj != null) {
+                        logger.info("Not adding child [{}] in group [{}] because it already exists",
+                            childToAddReference, groupReference);
                         continue;
                     }
+                    logger.debug("Adding child [{}] in group [{}]", childToAddReference, groupReference);
 
-                    // get unified list of users and groups, since they're added the same way
-                    def childrenOfGroup = ((groupsWithGroups.get(g) ?: []) + (groupsWithUsers.get(g) ?: [])).unique();
-
-                    logger.info("Importing group [{}] with children (users or groups) [{}]", g, childrenOfGroup);
-
-                    boolean wasCleaned = false
-                    def groupDoc = xwiki.getDocument(groupReference, context).clone()
-                    def groupNeedsSave = false;
-                    if (!groupDoc.isNew() &amp;&amp; cleanGroups) {
-                        logger.warn("Cleaning group [{}]", groupReference);
-                        groupDoc.removeXObjects(GROUP_CLASS)
-                        xwiki.saveDocument(groupDoc, "Cleaning the group upon group import", context)
-                        wasCleaned = true;
-                        // reload group doc from the database, to reset object numbers
-                        groupDoc = xwiki.getDocument(groupReference, context).clone();
-                    }
-                    if (wasCleaned || groupDoc.isNew()) {
-                        // initialize group with a first empty object
-                        def emptyObj = groupDoc.newXObject(GROUP_CLASS, context);
-                        emptyObj.set(GROUP_PROP, "", context);
-                        // set group as hidden, just in case it was not
-                        groupDoc.setHidden(true);
-                        groupNeedsSave = true;
-                    }
-                    // fill in all users and subgroups, if they're not already in the group
-                    for (def c : childrenOfGroup) {
-                        DocumentReference childToAddReference = new DocumentReference(c, XWIKI_SPACE);
-                        String serializedChildToAddReferenceLocal =
-                            serializer.serialize(childToAddReference, "local", groupReference);
-                        def existingMemberObj =
-                            groupDoc.getXObject(GROUP_CLASS, GROUP_PROP, serializedChildToAddReferenceLocal, false)
-                        // try with full reference if compact was not found
-                        if (existingMemberObj == null) {
-                            String serializedChildToAddReferenceFull =
-                                serializer.serialize(childToAddReference, "default")
-                            existingMemberObj =
-                                groupDoc.getXObject(GROUP_CLASS, GROUP_PROP, serializedChildToAddReferenceFull, false)
-                        }
-                        if (existingMemberObj != null) {
-                            logger.info("Not adding child [{}] in group [{}] because it already exists",
-                                childToAddReference, groupReference);
-                            continue;
-                        }
-                        logger.debug("Adding child [{}] in group [{}]", childToAddReference, groupReference);
-
-                        def newMemberObj = groupDoc.newXObject(GROUP_CLASS, context);
-                        newMemberObj.set(GROUP_PROP, serializedChildToAddReferenceLocal, context);
-                        groupNeedsSave = true;
-                    }
-
-                    // save the data at the end
-                    if (groupNeedsSave) {
-                        xwiki.saveDocument(groupDoc, "Imported group", context);
-                        logger.info("Saved group [{}] with [{}] children", groupReference, childrenOfGroup.size());
-                    }
-
-                    progress.endStep();
+                    def newMemberObj = groupDoc.newXObject(GROUP_CLASS, context);
+                    newMemberObj.set(GROUP_PROP, serializedChildToAddReferenceLocal, context);
+                    groupNeedsSave = true;
                 }
-                progress.popLevel();
-            } catch (Exception e) {
-                logger.error("Failed to load or process mapping from CSV: ", e);
+
+                // save the data at the end
+                if (groupNeedsSave) {
+                    xwiki.saveDocument(groupDoc, "Imported group", context);
+                    logger.info("Saved group [{}] with [{}] children", groupReference, childrenOfGroup.size());
+                }
+
+                progress.endStep();
             }
-        } else {
-            logger.error("Could not find one of files [{}], [{}], [{}] attached to this page", groupsInGroupsFilename,
-                usersInGroupsFilename, groupToMigrateFilename);
+            progress.popLevel();
+        } catch (Exception e) {
+            logger.error("Failed to load or process mapping from CSV: ", e);
         }
     }
     /**

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
@@ -61,18 +61,18 @@ See [[the SQL requests to perform on the Confluence database&gt;&gt;ConfluenceMi
       #pagePicker($pagePickerParams)
     &lt;/dd&gt;
     &lt;dt&gt;
-      &lt;label for="groupsparentsFilename"&gt;Attachment name for groups parents&lt;/label&gt;
+      &lt;label for="groupsInGroupsFilename"&gt;Attachment name for groups parents&lt;/label&gt;
       &lt;span class="xHint"&gt;Name of the attachment from which to read data to import&lt;/span&gt;
     &lt;/dt&gt;
     &lt;dd&gt;
-      &lt;input type="text" id="groupsparentsFilename" name="groupsparentsFilename" value="$!escapetool.xml($!request.groupsparentsFilename)" placeholder='groupsparents.csv'/&gt;
+      &lt;input type="text" id="groupsInGroupsFilename" name="groupsInGroupsFilename" value="$!escapetool.xml($!request.groupsInGroupsFilename)" placeholder='groupsparents.csv'/&gt;
     &lt;/dd&gt;
     &lt;dt&gt;
-      &lt;label for="usersgroupsFilename"&gt;Attachment name for users groups&lt;/label&gt;
+      &lt;label for="usersInGroupsFilename"&gt;Attachment name for users groups&lt;/label&gt;
       &lt;span class="xHint"&gt;Name of the attachment from which to read data to import&lt;/span&gt;
     &lt;/dt&gt;
     &lt;dd&gt;
-      &lt;input type="text" id="usersgroupsFilename" name="usersgroupsFilename" value="$!escapetool.xml($!request.usersgroupsFilename)" placeholder='usersgroups.csv'/&gt;
+      &lt;input type="text" id="usersInGroupsFilename" name="usersInGroupsFilename" value="$!escapetool.xml($!request.usersInGroupsFilename)" placeholder='usersgroups.csv'/&gt;
     &lt;/dd&gt;
     &lt;dt&gt;
       &lt;label for="groupToMigrateFilename"&gt;Attachment name for groups to migrate&lt;/label&gt;

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
@@ -347,6 +347,11 @@ public class GroupMigratorScriptService implements ScriptService
         String groupsInGroupsFilename, String usersInGroupsFilename, String groupToMigrateFilename,
         DocumentReference sourcePageRef)
     {
+        logger.debug('Calling group import with params: processAdmin [{}], cleanGroups [{}], ' +
+            'groupsInGroupsFilename [{}], usersInGroupsFilename [{}], groupToMigrateFilename [{}], sourcePageRef [{}]',
+            processAdmin, cleanGroups, groupsInGroupsFilename, usersInGroupsFilename, groupToMigrateFilename,
+            sourcePageRef)
+
         XWikiContext context = contextProvider.get()
         XWiki xwiki = context.getWiki()
 

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/GroupsImporter/WebHome.xml
@@ -303,6 +303,7 @@ import com.xpn.xwiki.doc.XWikiAttachment
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser
 import org.apache.commons.csv.CSVRecord
+import org.apache.commons.io.input.BOMInputStream
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.Logger
 import org.xwiki.component.annotation.Component
@@ -367,19 +368,19 @@ public class GroupMigratorScriptService implements ScriptService
 
                 logger.info("Processed [{}] groups with users", groupsWithUsers ? groupsWithUsers.size() : 0)
 
-                // 3. read the list of groups to migrate and prepare the full list of groups to create (including child groups)
-                InputStream is = groupsToMigrateFile.getContentInputStream(context);
-                InputStreamReader isr = new InputStreamReader(is);
-                CSVParser parser = CSVFormat.RFC4180.builder()
-                    .setHeader().setSkipHeaderRecord(true).setTrim(true).setDelimiter(';')
-                    .build()
-                    .parse(isr)
+            logger.info("Processed [{}] groups with users", groupsWithUsers ? groupsWithUsers.size() : 0)
 
-                List&lt;String&gt; groupsToMigrateFirstLevel = [];
-                parser.each { record -&gt;
-                    groupsToMigrateFirstLevel &lt;&lt; confluenceConverter.toGroupReferenceName(record.get(0));
-                }
-                isr.close()
+            // 3. read the list of groups to migrate and prepare the full list of groups to create (including child groups)
+            // Take care of wrapping it into a BOMInputStream to avoid any issue
+            // in case of the input file contains BOM header. Note that the apache common parser don't support BOM header and
+            // and raise strange issue in case of BOM headers. Note that microsoft except can generate CSV with BOM.
+            InputStream is =
+                BOMInputStream.builder().setInputStream(groupsToMigrateFile.getContentInputStream(context)).get()
+            InputStreamReader isr = new InputStreamReader(is);
+            CSVParser parser = CSVFormat.RFC4180.builder()
+                .setHeader().setSkipHeaderRecord(true).setTrim(true).setDelimiter(';')
+                .build()
+                .parse(isr)
 
                 Set&lt;String&gt; allGroupsToMigrateSet = new LinkedHashSet&lt;&gt;();
                 groupsToMigrateFirstLevel.each { traverse(it, groupsWithGroups, allGroupsToMigrateSet) };
@@ -485,7 +486,11 @@ public class GroupMigratorScriptService implements ScriptService
     {
         Map&lt;String, List&lt;String&gt;&gt; result = new TreeMap&lt;String, List&lt;String&gt;&gt;();
 
-        InputStream is = pairsFile.getContentInputStream(contextProvider.get());
+        // Take care of wrapping it into a BOMInputStream to avoid any issue
+        // in case of the input file contains BOM header. Note that the apache common parser don't support BOM header and
+        // and raise strange issue in case of BOM headers. Note that microsoft except can generate CSV with BOM.
+        InputStream is =
+            BOMInputStream.builder().setInputStream(pairsFile.getContentInputStream(contextProvider.get())).get()
         InputStreamReader isr = new InputStreamReader(is);
         CSVParser parser = CSVFormat.RFC4180.builder()
             .setHeader().setSkipHeaderRecord(true).setTrim(true).setDelimiter(';')


### PR DESCRIPTION
# Issue URL

#451, #452

# Changes

## Description

Fix bug related to #451.

For #452, I found that we have the apache BOMInputStream class which provide the need. This way if there are BOM header we just remove it and this way the CSV parser work as expected.

I also adapted the text about the requirement of the CSV. Previously I mentioned that we required the line return in Unix format based on the fact that a file with BOM converted to Unix format with `dos2unix` have BOM removed. But the issue was not related to the line return but to the BOM. So my state is that now with this fix we *should support any* line return and a file with and without BOM. But for safety would still recommend to ensure the Linux format because  it's the format that we test the more deeply.

# Executed Tests

Tried import with CSV file with BOM header and it work now.

# Expected merging strategy

* Prefers squash: No, because different related issues