### PR TITLE
Accessibility issues with collapsible sections that don't use details…

### DIFF
--- a/application-confluence-migrator-pro-test/application-confluence-migrator-pro-test-pageobjects/src/main/java/com/xwiki/confluencepro/test/po/ConfluenceHomePage.java
+++ b/application-confluence-migrator-pro-test/application-confluence-migrator-pro-test-pageobjects/src/main/java/com/xwiki/confluencepro/test/po/ConfluenceHomePage.java
@@ -106,7 +106,7 @@ public class ConfluenceHomePage extends ViewPage
     public void openHowToMigrateSubsection(String subsectionClass)
     {
         getDriver().setDriverImplicitWait();
-        WebElement subsections = getDriver().findElement(By.cssSelector(subsectionClass + " > summary"));
+        WebElement subsections = getDriver().findElement(By.cssSelector(subsectionClass + " summary.cfmTitleSection"));
         subsections.click();
     }
 

--- a/application-confluence-migrator-pro-test/application-confluence-migrator-pro-test-pageobjects/src/main/java/com/xwiki/confluencepro/test/po/ConfluenceHomePage.java
+++ b/application-confluence-migrator-pro-test/application-confluence-migrator-pro-test-pageobjects/src/main/java/com/xwiki/confluencepro/test/po/ConfluenceHomePage.java
@@ -106,7 +106,7 @@ public class ConfluenceHomePage extends ViewPage
     public void openHowToMigrateSubsection(String subsectionClass)
     {
         getDriver().setDriverImplicitWait();
-        WebElement subsections = getDriver().findElement(By.cssSelector(subsectionClass + " .cfmTitleIcon"));
+        WebElement subsections = getDriver().findElement(By.cssSelector(subsectionClass + " > summary"));
         subsections.click();
     }
 

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/CommonCode.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/CommonCode.xml
@@ -702,7 +702,7 @@ details[open] &gt; summary .cfmTitleIcon {
 }
 
 summary.advanced-fields {
-  color: @link-color;
+  color: var(--link-color, #0088cc);
   list-style: none;
   display: inline-flex;
   align-items: center;
@@ -710,7 +710,7 @@ summary.advanced-fields {
 }
 
 summary.advanced-fields:hover {
-  color: @link-hover-color;
+  color: var(--link-hover-color, #005580);
 }
 
 summary.advanced-fields .advanced-fields-label {

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/CommonCode.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/CommonCode.xml
@@ -680,9 +680,7 @@ require(['jquery', 'xwiki-l10n!confluencemigratorpro.javascript'], function ($, 
   transition: all 0.5s;
 }
 
-.cfmTitleIcon.active {
-  -webkit-transform: rotate(180deg);
-  -moz-transform: rotate(180deg);
+details[open] &gt; summary .cfmTitleIcon {
   transform: rotate(180deg);
 }
 
@@ -701,6 +699,22 @@ require(['jquery', 'xwiki-l10n!confluencemigratorpro.javascript'], function ($, 
 
 .specified-migration.migrationOptionsSelect {
   width: fit-content;
+}
+
+summary.advanced-fields {
+  color: @link-color;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+summary.advanced-fields:hover {
+  color: @link-hover-color;
+}
+
+summary.advanced-fields .advanced-fields-label {
+  text-decoration: underline;
 }</code>
     </property>
     <property>

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
@@ -368,17 +368,18 @@
         #set ($spaceHomeEntityReference = $services.modelvalidation.transformEntityReference($services.model.createDocumentReference("WebHome", $spaceRef)))
         #set ($spaceHomeRef = $services.model.serialize($spaceHomeEntityReference))
         &lt;li&gt;
-          &lt;a role="button" data-toggle="collapse" href="#importedSpace${foreach.count}" aria-expanded="false" aria-controls="importedSpace${foreach.count}"&gt;
+        &lt;details class="imported-space"&gt;
+          &lt;summary&gt;
             $services.icon.renderHTML('caret-down')
             &lt;p class="sr-only"&gt;$services.localization.render("cfm.sr-only.migrationSheet.expandMigratedSpaces")&lt;p&gt;
           &lt;/a&gt;
           [[$services.rendering.escape($services.rendering.escape($space, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$services.rendering.escape($spaceHomeRef, $xwiki.currentContentSyntaxId)]]
+          &lt;/summary&gt;
           #set ($discard = $options.put('root', "document:$spaceHomeRef"))
           #set ($discard = $options.put('links', 'true'))
           #set ($discard = $options.put('compact', 'true'))
-          &lt;div id="importedSpace${foreach.count}" class="imported-space collapse"&gt;
-            #documentTree($options)
-          &lt;/div&gt;
+          #documentTree($options)
+         &lt;/details&gt;
         &lt;/li&gt;
       #end
     &lt;/ul&gt;
@@ -841,8 +842,8 @@
       #set ($docRef = $services.model.resolveDocument($entry.key))
     #end
     &lt;li class="cfm-problem-page"&gt;
-      &lt;div class="cfm-page"&gt;
-        &lt;a role="button" data-toggle="collapse" href="#cfmPage-${category}-${foreach.count}" aria-expanded="false" aria-controls="cfmPage-${category}-${foreach.count}"&gt;
+      &lt;details class="cfm-page-details"&gt;
+        &lt;summary class="cfm-page"&gt;
           &lt;div class="cfmTitleIcon"&gt;
             $services.icon.renderHTML('caret-down')
             &lt;span class="sr-only"&gt;$services.localization.render("cfm.sr-only.migrationSheet.missingReferences")&lt;span&gt;
@@ -853,9 +854,8 @@
         #else
           $escapetool.xml($entry.key)
         #end
-      &lt;/div&gt;
-      &lt;div id="cfmPage-${category}-${foreach.count}" class="cfm-problems collapse"&gt;
-        &lt;ul&gt;
+      &lt;/summary&gt;
+        &lt;ul class="cfm-problems"&gt;
           #foreach ($problem in $entry.value)
             &lt;li class="cfm-problem"&gt;
               #set ($msg = $problem.get("msg"))
@@ -870,7 +870,7 @@
             &lt;/li&gt;
           #end
         &lt;/ul&gt;
-      &lt;/div&gt;
+      &lt;/details&gt;
     &lt;/li&gt;
   #end
   &lt;/ul&gt;

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
@@ -91,18 +91,18 @@
     #end
   &lt;/div&gt;
   ## Advanced options
- &lt;details class="advancedInputFieldsDetails"&gt;
-  &lt;summary class="advanced-fields"&gt;
-    &lt;span class="cfmTitleIcon"&gt;
-      $services.icon.renderHTML('caret-down')
+  &lt;details class="advancedInputFieldsDetails"&gt;
+    &lt;summary class="advanced-fields"&gt;
+      &lt;span class="cfmTitleIcon"&gt;
+        $services.icon.renderHTML('caret-down')
+      &lt;/span&gt;
+      &lt;span class="advanced-fields-label"&gt;
+        $escapetool.xml($services.localization.render('confluencepro.job.question.advanced.link'))
+      &lt;/span&gt;
+    &lt;/summary&gt;
+    &lt;span class="xform confluence-migrator" id="advancedInputFields"&gt;
+      #displayMigrationParameterFormFields
     &lt;/span&gt;
-    &lt;span class="advanced-fields-label"&gt;
-      $escapetool.xml($services.localization.render('confluencepro.job.question.advanced.link'))
-    &lt;/span&gt;
-  &lt;/summary&gt;
-  &lt;span class="xform confluence-migrator" id="advancedInputFields"&gt;
-    #displayMigrationParameterFormFields
-  &lt;/span&gt;
   &lt;/details&gt;
   {{/html}}
 
@@ -372,18 +372,19 @@
         #set ($spaceHomeEntityReference = $services.modelvalidation.transformEntityReference($services.model.createDocumentReference("WebHome", $spaceRef)))
         #set ($spaceHomeRef = $services.model.serialize($spaceHomeEntityReference))
         &lt;li&gt;
-        &lt;details class="imported-space"&gt;
-          &lt;summary&gt;
-            $services.icon.renderHTML('caret-down')
-            &lt;p class="sr-only"&gt;$services.localization.render("cfm.sr-only.migrationSheet.expandMigratedSpaces")&lt;p&gt;
-          &lt;/a&gt;
-          [[$services.rendering.escape($services.rendering.escape($space, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$services.rendering.escape($spaceHomeRef, $xwiki.currentContentSyntaxId)]]
-          &lt;/summary&gt;
-          #set ($discard = $options.put('root', "document:$spaceHomeRef"))
-          #set ($discard = $options.put('links', 'true'))
-          #set ($discard = $options.put('compact', 'true'))
-          #documentTree($options)
-         &lt;/details&gt;
+          &lt;details class="imported-space"&gt;
+            &lt;summary&gt;
+              $services.icon.renderHTML('caret-down')
+              &lt;p class="sr-only"&gt;$services.localization.render("cfm.sr-only.migrationSheet.expandMigratedSpaces")&lt;p&gt;
+              [[$services.rendering.escape($services.rendering.escape($space, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$services.rendering.escape($spaceHomeRef, $xwiki.currentContentSyntaxId)]]
+            &lt;/summary&gt;
+            #set ($discard = $options.put('root', "document:$spaceHomeRef"))
+            #set ($discard = $options.put('links', 'true'))
+            #set ($discard = $options.put('compact', 'true'))
+            &lt;div id="importedSpace${foreach.count}" class="imported-space"&gt;
+              #documentTree($options)
+            &lt;/div&gt;
+          &lt;/details&gt;
         &lt;/li&gt;
       #end
     &lt;/ul&gt;

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/MigrationSheet.xml
@@ -91,15 +91,19 @@
     #end
   &lt;/div&gt;
   ## Advanced options
-  &lt;a data-toggle="collapse" href="#advancedInputFields" role="button" aria-expanded="false" aria-controls="advancedInputFields" class="advanced-fields collapsed"&gt;
-    &lt;div class="cfmTitleIcon"&gt;
+ &lt;details class="advancedInputFieldsDetails"&gt;
+  &lt;summary class="advanced-fields"&gt;
+    &lt;span class="cfmTitleIcon"&gt;
       $services.icon.renderHTML('caret-down')
-    &lt;/div&gt;
-    $escapetool.xml($services.localization.render('confluencepro.job.question.advanced.link'))
-  &lt;/a&gt;
-  &lt;div class="xform collapse confluence-migrator-collapse" id="advancedInputFields"&gt;
+    &lt;/span&gt;
+    &lt;span class="advanced-fields-label"&gt;
+      $escapetool.xml($services.localization.render('confluencepro.job.question.advanced.link'))
+    &lt;/span&gt;
+  &lt;/summary&gt;
+  &lt;span class="xform confluence-migrator" id="advancedInputFields"&gt;
     #displayMigrationParameterFormFields
-  &lt;/div&gt;
+  &lt;/span&gt;
+  &lt;/details&gt;
   {{/html}}
 
 #end

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
@@ -104,6 +104,7 @@
 &lt;div class="howToMigrateSubsection"&gt;
   &lt;details class="uploadSubsection"&gt;
     #displaySubsection('caret-down', 'confluencepro.howToMigrate.upload.title', 'cfmTitleSection', {})
+    &lt;br/&gt;
     &lt;div id="cfmHowToMigrateUploadCollapse"&gt;
       &lt;div&gt;
         &lt;button id="facade-upload-button" class="btn btn-primary"&gt;$services.icon.renderHTML('add') $escapetool.xml($services.localization.render('confluencepro.uploadFacadeButton'))&lt;/button&gt;
@@ -142,6 +143,7 @@
 &lt;div class="howToMigrateSubsection"&gt;
   &lt;details class="serverSubsection"&gt;
     #displaySubsection('caret-down', 'confluencepro.howToMigrate.server.title', 'cfmTitleSection', {})
+    &lt;br/&gt;
     &lt;div id="cfmHowToMigrateServerCollapse" class="cfmPrerequisites"&gt;
       #set ($escapedMessage = $escapetool.xml($services.localization.render('confluencepro.packages.serverPath')))
       #set ($editURL = $xwiki.getURL("ConfluenceMigratorPro.Migrations.Migration${datetool.date.time}", 'edit', $escapetool.url({
@@ -170,6 +172,7 @@
 &lt;div class="howToMigrateSubsection"&gt;
   &lt;details class="batchSubsection"&gt;
     #displaySubsection('caret-down', 'confluencepro.howToMigrate.batch.title', 'cfmTitleSection', {})
+    &lt;br/&gt;
     &lt;div id="cfmHowToMigrateBatchesCollapse" class="cfmPrerequisites"&gt;
       &lt;div&gt;
         &lt;a href="$xwiki.getURL('ConfluenceMigratorPro.ConfluenceBatches.New')"&gt;
@@ -208,6 +211,7 @@
         sourceParameters="$parameters"
         sort='creationDate:desc'
         limit="10"}}$jsontool.serialize($liveDataConfig){{/liveData}}
+        
     &lt;/div&gt;
   &lt;/details&gt;
 &lt;/div&gt;

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
@@ -46,7 +46,7 @@
 {{/velocity}}
 {{velocity}}
 #macro (displaySubsection $icon $key $class $params)
-&lt;summary class="$cfmTitle $!class"&gt;
+&lt;summary class="cfmTitle $!class"&gt;
   &lt;span&gt;
     &lt;span class="cfmTitleIcon"&gt;
       $services.icon.renderHTML($icon)
@@ -101,120 +101,111 @@
 {{/html}}
 #end
 #macro (howToMigrateUploadSubsection)
-&lt;div class="howToMigrateSubsection"&gt;
-  &lt;details class="uploadSubsection"&gt;
-    #displaySubsection('caret-down', 'confluencepro.howToMigrate.upload.title', 'cfmTitleSection', {})
-    &lt;br/&gt;
-    &lt;div id="cfmHowToMigrateUploadCollapse"&gt;
-      &lt;div&gt;
-        &lt;button id="facade-upload-button" class="btn btn-primary"&gt;$services.icon.renderHTML('add') $escapetool.xml($services.localization.render('confluencepro.uploadFacadeButton'))&lt;/button&gt;
-        &lt;div id='facade-upload-progress'&gt;&lt;/div&gt;
-      &lt;/div&gt;
-      #set ($storeDoc = $xwiki.getDocument('ConfluenceMigratorPro.Code.PackagesStore'))
-      #if ($hasEdit || $hasAdmin)
-        ## Hide the form because it comes from the platform, and we cannot customize its appearance. We are using a 'facade' button to trigger the upload via JS.
-        &lt;form action="$storeDoc.getURL("upload")" enctype="multipart/form-data" method="post" id="addConfluencePackage"&gt;
+&lt;details class="howToMigrateSubsection uploadSubsection"&gt;
+  #displaySubsection('caret-down', 'confluencepro.howToMigrate.upload.title', 'cfmTitleSection', {})
+  &lt;div id="cfmHowToMigrateUploadCollapse"&gt;
+    &lt;div&gt;
+      &lt;button id="facade-upload-button" class="btn btn-primary"&gt;$services.icon.renderHTML('add') $escapetool.xml($services.localization.render('confluencepro.uploadFacadeButton'))&lt;/button&gt;
+      &lt;div id='facade-upload-progress'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+    #set ($storeDoc = $xwiki.getDocument('ConfluenceMigratorPro.Code.PackagesStore'))
+    #if ($hasEdit || $hasAdmin)
+      ## Hide the form because it comes from the platform, and we cannot customize its appearance. We are using a 'facade' button to trigger the upload via JS.
+      &lt;form action="$storeDoc.getURL("upload")" enctype="multipart/form-data" method="post" id="addConfluencePackage"&gt;
+        &lt;div&gt;
+          ## CSRF prevention
+          &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
           &lt;div&gt;
-            ## CSRF prevention
-            &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
-            &lt;div&gt;
-              &lt;div class="fileupload-field"&gt;
-                &lt;label class="sr-only" for="confluenceUploadFile"&gt;$escapetool.xml(
-                    $services.localization.render('core.viewers.attachments.upload.file'))&lt;/label&gt;
-                &lt;input id="confluenceUploadFile" type="file" name="filepath" size="40" class="uploadFileInput noitems hidden"
-                    data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" accept=".zip"/&gt;
-              &lt;/div&gt;
+            &lt;div class="fileupload-field"&gt;
+              &lt;label class="sr-only" for="confluenceUploadFile"&gt;$escapetool.xml(
+                  $services.localization.render('core.viewers.attachments.upload.file'))&lt;/label&gt;
+              &lt;input id="confluenceUploadFile" type="file" name="filepath" size="40" class="uploadFileInput noitems hidden"
+                  data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" accept=".zip"/&gt;
             &lt;/div&gt;
           &lt;/div&gt;
-        &lt;/form&gt;
-      #end
+        &lt;/div&gt;
+      &lt;/form&gt;
+    #end
 
-      #showAttachmentsLiveData($storeDoc 'confluencePackages')
+    #showAttachmentsLiveData($storeDoc 'confluencePackages')
 
-      {{html}}
-        #displayPrefillForm("cmpUploadPackageMigrationSettingsForm")
-      {{/html}}
+    {{html}}
+      #displayPrefillForm("cmpUploadPackageMigrationSettingsForm")
+    {{/html}}
 
-    &lt;/div&gt;
-  &lt;/details&gt;
-&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/details&gt;
 #end
 #macro (howToMigrateServerSection)
-&lt;div class="howToMigrateSubsection"&gt;
-  &lt;details class="serverSubsection"&gt;
-    #displaySubsection('caret-down', 'confluencepro.howToMigrate.server.title', 'cfmTitleSection', {})
-    &lt;br/&gt;
-    &lt;div id="cfmHowToMigrateServerCollapse" class="cfmPrerequisites"&gt;
-      #set ($escapedMessage = $escapetool.xml($services.localization.render('confluencepro.packages.serverPath')))
-      #set ($editURL = $xwiki.getURL("ConfluenceMigratorPro.Migrations.Migration${datetool.date.time}", 'edit', $escapetool.url({
-        'template': 'ConfluenceMigratorPro.Code.MigrationTemplate',
-        'parent': 'ConfluenceMigratorPro.Migrations.WebHome',
-        'isPath': '1',
-        'form_token': $services.csrf.token
-      })))
-      #set ($escapedMessage = $stringtool.replace($escapedMessage, '&amp;#123;0}', "&lt;button class='btn btn-primary'&gt;$services.icon.renderHTML('drive') "))
-      #set ($escapedMessage = $stringtool.replace($escapedMessage, '&amp;#123;1}', '&lt;/button&gt;'))
-      &lt;form method="post" action="$escapetool.xml($editURL)"&gt;
-        &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
-        &lt;p&gt;$escapedMessage&lt;/p&gt;
+&lt;details class="howToMigrateSubsection serverSubsection"&gt;
+  #displaySubsection('caret-down', 'confluencepro.howToMigrate.server.title', 'cfmTitleSection', {})
+  &lt;div id="cfmHowToMigrateServerCollapse" class="cfmPrerequisites"&gt;
+    #set ($escapedMessage = $escapetool.xml($services.localization.render('confluencepro.packages.serverPath')))
+    #set ($editURL = $xwiki.getURL("ConfluenceMigratorPro.Migrations.Migration${datetool.date.time}", 'edit', $escapetool.url({
+      'template': 'ConfluenceMigratorPro.Code.MigrationTemplate',
+      'parent': 'ConfluenceMigratorPro.Migrations.WebHome',
+      'isPath': '1',
+      'form_token': $services.csrf.token
+    })))
+    #set ($escapedMessage = $stringtool.replace($escapedMessage, '&amp;#123;0}', "&lt;button class='btn btn-primary'&gt;$services.icon.renderHTML('drive') "))
+    #set ($escapedMessage = $stringtool.replace($escapedMessage, '&amp;#123;1}', '&lt;/button&gt;'))
+    &lt;form method="post" action="$escapetool.xml($editURL)"&gt;
+      &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
+      &lt;p&gt;$escapedMessage&lt;/p&gt;
 
-        {{html}}
-          ## In this case, the class is here only to make the DOM easier to read, since these fields are already in the form and are submitted when the select from server is pressed.
-          #displayPrefillForm("cmpServerMigrationSettingsForm")
-        {{/html}}
+      {{html}}
+        ## In this case, the class is here only to make the DOM easier to read, since these fields are already in the form and are submitted when the select from server is pressed.
+        #displayPrefillForm("cmpServerMigrationSettingsForm")
+      {{/html}}
 
-      &lt;/form&gt;
-    &lt;/div&gt;
-  &lt;/details&gt;
-&lt;/div&gt;
+    &lt;/form&gt;
+  &lt;/div&gt;
+&lt;/details&gt;
 #end
 #macro (howToMigrateBatches)
-&lt;div class="howToMigrateSubsection"&gt;
-  &lt;details class="batchSubsection"&gt;
-    #displaySubsection('caret-down', 'confluencepro.howToMigrate.batch.title', 'cfmTitleSection', {})
-    &lt;br/&gt;
-    &lt;div id="cfmHowToMigrateBatchesCollapse" class="cfmPrerequisites"&gt;
-      &lt;div&gt;
-        &lt;a href="$xwiki.getURL('ConfluenceMigratorPro.ConfluenceBatches.New')"&gt;
-          &lt;button id="createNewBatchButton" class='btn btn-primary'&gt;$services.icon.renderHTML('add')
-          $escapetool.xml($services.localization.render('confluencemigratorpro.baches.uploadButton'))&lt;/button&gt;
-        &lt;/a&gt;
-      &lt;/div&gt;
-      &lt;div&gt;
-        &lt;br/&gt;
-        &lt;span&gt;$escapetool.xml($services.localization.render('confluencemigratorpro.baches.section.hint'))&lt;/span&gt;
-        &lt;br/&gt;
-      &lt;/div&gt;
-      #set ($parameters = $escapetool.url({
-        'resultPage': 'ConfluenceMigratorPro.ConfluenceBatches.Code.BatchesLiveDataSource',
-        'translationPrefix': 'confluencemigratorpro.batches.header.'
-      }))
-      #set ($liveDataConfig= {
-        'meta': {
-          'propertyDescriptors': [
-            {'id': 'pageName', 'displayer': 'html'},
-            {'id': 'totalSize', 'displayer': 'html'},
-            {'id': 'creationDate', 'displayer': 'date'},
-            {'id': 'author', 'displayer': 'html'},
-            {'id': 'actions', 'displayer': 'html'}
-          ],
-          'entryDescriptor': {
-            'idProperty': 'pageName'
-          }
-        }
-      })
-
-      {{liveData
-        id="confluenceMigratorProBatches"
-        properties="pageName,totalSize, creationDate, author, actions"
-        source='liveTable'
-        sourceParameters="$parameters"
-        sort='creationDate:desc'
-        limit="10"}}$jsontool.serialize($liveDataConfig){{/liveData}}
-        
+&lt;details class="howToMigrateSubsection batchSubsection"&gt;
+  #displaySubsection('caret-down', 'confluencepro.howToMigrate.batch.title', 'cfmTitleSection', {})
+  &lt;div id="cfmHowToMigrateBatchesCollapse" class="cfmPrerequisites"&gt;
+    &lt;div&gt;
+      &lt;a href="$xwiki.getURL('ConfluenceMigratorPro.ConfluenceBatches.New')"&gt;
+        &lt;button id="createNewBatchButton" class='btn btn-primary'&gt;$services.icon.renderHTML('add')
+        $escapetool.xml($services.localization.render('confluencemigratorpro.baches.uploadButton'))&lt;/button&gt;
+      &lt;/a&gt;
     &lt;/div&gt;
-  &lt;/details&gt;
-&lt;/div&gt;
+    &lt;div&gt;
+      &lt;br/&gt;
+      &lt;span&gt;$escapetool.xml($services.localization.render('confluencemigratorpro.baches.section.hint'))&lt;/span&gt;
+      &lt;br/&gt;
+    &lt;/div&gt;
+    #set ($parameters = $escapetool.url({
+      'resultPage': 'ConfluenceMigratorPro.ConfluenceBatches.Code.BatchesLiveDataSource',
+      'translationPrefix': 'confluencemigratorpro.batches.header.'
+    }))
+    #set ($liveDataConfig= {
+      'meta': {
+        'propertyDescriptors': [
+          {'id': 'pageName', 'displayer': 'html'},
+          {'id': 'totalSize', 'displayer': 'html'},
+          {'id': 'creationDate', 'displayer': 'date'},
+          {'id': 'author', 'displayer': 'html'},
+          {'id': 'actions', 'displayer': 'html'}
+        ],
+        'entryDescriptor': {
+          'idProperty': 'pageName'
+        }
+      }
+    })
+
+    {{liveData
+      id="confluenceMigratorProBatches"
+      properties="pageName,totalSize, creationDate, author, actions"
+      source='liveTable'
+      sourceParameters="$parameters"
+      sort='creationDate:desc'
+      limit="10"}}$jsontool.serialize($liveDataConfig){{/liveData}}
+        
+  &lt;/div&gt;
+&lt;/details&gt;
 #end
 #macro (howToMigrate)
 {{html wiki="true"}}
@@ -342,31 +333,6 @@ $xwiki.jsfx.use('js/xwiki/viewers/attachments.js', {'forceSkinAction': true, 'la
       <code>require(['jquery'], function($){
   $('#facade-upload-button').on('click', function(){
     $('#confluenceUploadFile').click();
-  });
-
-  function isAnyOpen() {
-    return $('.howToMigrateSubsection &gt; details').toArray().some(el =&gt; el.open);
-  }
-
-  function updateFontWeight() {
-    let anyOpen = isAnyOpen();
-    $('.howToMigrateSubsection &gt; details &gt; summary.cfmTitleSection').css(
-      'font-weight', anyOpen ? 'bold' : 'normal'
-    );
-  }
-
-  // We use an observer because the collapse class is added via js and we might
-  // reach some cases were the on click event is handled before the class is added/removed.
-  const observer = new MutationObserver(function(mutations) {
-    mutations.forEach(function(mutation) {
-      if (mutation.type === 'attributes' &amp;&amp; mutation.attributeName === 'open') {
-        updateFontWeight(); // Run the function when class is changed
-      }
-    });
-  });
-
-  $('.howToMigrateSubsection &gt; details').each(function() {
-    observer.observe(this, { attributes: true });
   });
 });</code>
     </property>

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
@@ -45,8 +45,8 @@
 #template('attachment_macros.vm')
 {{/velocity}}
 {{velocity}}
-#macro (displaySubsection $icon $key $class $params $summaryClass)
-&lt;summary class="$summaryClass $!class"&gt;
+#macro (displaySubsection $icon $key $class $params)
+&lt;summary class="$cfmTitle $!class"&gt;
   &lt;span&gt;
     &lt;span class="cfmTitleIcon"&gt;
       $services.icon.renderHTML($icon)
@@ -76,72 +76,72 @@
 {{html}}
 &lt;div class="cfmTitle"&gt;
   &lt;details class="cfmPrerequisitesDetails"&gt;
-    #displaySubsection('caret-down', 'confluencepro.prerequisites.title', $prerequisitesComplete, {}, 'cfmTitleSummary')
-  &lt;div class="cfmPrerequisites"&gt;
-  &lt;div class="box infomessage"&gt;
-    &lt;p&gt;$escapetool.xml($services.localization.render('confluencepro.prerequisites.hint'))&lt;/p&gt;
-  &lt;/div&gt;
-  &lt;ul&gt;
-  #foreach($prerequisite in $prerequisites)
-    &lt;li&gt;
-      $services.icon.renderHTML($prerequisite.icon)
-      #if ("$prerequisite.url" != '')
-        &lt;a href="$prerequisite.url" target="_blank"&gt;
-          $escapetool.xml($services.localization.render($prerequisite.translationKey, $prerequisite.params))
-        &lt;/a&gt;
-      #else
-        $escapetool.xml($services.localization.render($prerequisite.translationKey, $prerequisite.params))
-      #end
-    &lt;/li&gt;
-  #end
-  &lt;/ul&gt;
+    #displaySubsection('caret-down', 'confluencepro.prerequisites.title', "cfmTitleSummary $prerequisitesComplete", {})
+    &lt;div class="cfmPrerequisites"&gt;
+      &lt;div class="box infomessage"&gt;
+        &lt;p&gt;$escapetool.xml($services.localization.render('confluencepro.prerequisites.hint'))&lt;/p&gt;
+      &lt;/div&gt;
+      &lt;ul&gt;
+        #foreach($prerequisite in $prerequisites)
+        &lt;li&gt;
+          $services.icon.renderHTML($prerequisite.icon)
+          #if ("$prerequisite.url" != '')
+            &lt;a href="$prerequisite.url" target="_blank"&gt;
+              $escapetool.xml($services.localization.render($prerequisite.translationKey, $prerequisite.params))
+            &lt;/a&gt;
+          #else
+            $escapetool.xml($services.localization.render($prerequisite.translationKey, $prerequisite.params))
+          #end
+        &lt;/li&gt;
+        #end
+      &lt;/ul&gt;
+    &lt;/div&gt;
+  &lt;/details&gt;
 &lt;/div&gt;
-&lt;/details&gt;
 {{/html}}
 #end
 #macro (howToMigrateUploadSubsection)
 &lt;div class="howToMigrateSubsection"&gt;
- &lt;details class ="uploadSubsection"&gt;
-  #displaySubsection('caret-down', 'confluencepro.howToMigrate.upload.title', '', {}, 'cfmTitleSection')
+  &lt;details class="uploadSubsection"&gt;
+    #displaySubsection('caret-down', 'confluencepro.howToMigrate.upload.title', 'cfmTitleSection', {})
     &lt;div id="cfmHowToMigrateUploadCollapse"&gt;
-    &lt;div&gt;
-      &lt;button id="facade-upload-button" class="btn btn-primary"&gt;$services.icon.renderHTML('add') $escapetool.xml($services.localization.render('confluencepro.uploadFacadeButton'))&lt;/button&gt;
-      &lt;div id='facade-upload-progress'&gt;&lt;/div&gt;
+      &lt;div&gt;
+        &lt;button id="facade-upload-button" class="btn btn-primary"&gt;$services.icon.renderHTML('add') $escapetool.xml($services.localization.render('confluencepro.uploadFacadeButton'))&lt;/button&gt;
+        &lt;div id='facade-upload-progress'&gt;&lt;/div&gt;
+      &lt;/div&gt;
+      #set ($storeDoc = $xwiki.getDocument('ConfluenceMigratorPro.Code.PackagesStore'))
+      #if ($hasEdit || $hasAdmin)
+        ## Hide the form because it comes from the platform, and we cannot customize its appearance. We are using a 'facade' button to trigger the upload via JS.
+        &lt;form action="$storeDoc.getURL("upload")" enctype="multipart/form-data" method="post" id="addConfluencePackage"&gt;
+          &lt;div&gt;
+            ## CSRF prevention
+            &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
+            &lt;div&gt;
+              &lt;div class="fileupload-field"&gt;
+                &lt;label class="sr-only" for="confluenceUploadFile"&gt;$escapetool.xml(
+                    $services.localization.render('core.viewers.attachments.upload.file'))&lt;/label&gt;
+                &lt;input id="confluenceUploadFile" type="file" name="filepath" size="40" class="uploadFileInput noitems hidden"
+                    data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" accept=".zip"/&gt;
+              &lt;/div&gt;
+            &lt;/div&gt;
+          &lt;/div&gt;
+        &lt;/form&gt;
+      #end
+
+      #showAttachmentsLiveData($storeDoc 'confluencePackages')
+
+      {{html}}
+        #displayPrefillForm("cmpUploadPackageMigrationSettingsForm")
+      {{/html}}
+
     &lt;/div&gt;
-
-    #set ($storeDoc = $xwiki.getDocument('ConfluenceMigratorPro.Code.PackagesStore'))
-    #if ($hasEdit || $hasAdmin)
-      ## Hide the form because it comes from the platform, and we cannot customize its appearance. We are using a 'facade' button to trigger the upload via JS.
-      &lt;form action="$storeDoc.getURL("upload")" enctype="multipart/form-data" method="post" id="addConfluencePackage"&gt;
-      &lt;div&gt;
-      ## CSRF prevention
-      &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
-      &lt;div&gt;
-        &lt;div class="fileupload-field"&gt;
-          &lt;label class="sr-only" for="confluenceUploadFile"&gt;$escapetool.xml(
-            $services.localization.render('core.viewers.attachments.upload.file'))&lt;/label&gt;
-          &lt;input id="confluenceUploadFile" type="file" name="filepath" size="40" class="uploadFileInput noitems hidden"
-            data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" accept=".zip"/&gt;
-        &lt;/div&gt;
-      &lt;/div&gt;
-      &lt;/div&gt;
-      &lt;/form&gt;
-    #end
-
-    #showAttachmentsLiveData($storeDoc 'confluencePackages')
-
-    {{html}}
-      #displayPrefillForm("cmpUploadPackageMigrationSettingsForm")
-    {{/html}}
-
-  &lt;/div&gt;
   &lt;/details&gt;
 &lt;/div&gt;
 #end
 #macro (howToMigrateServerSection)
 &lt;div class="howToMigrateSubsection"&gt;
-  &lt;details class = "serverSubsection"&gt;
-  #displaySubsection('caret-down', 'confluencepro.howToMigrate.server.title', '', {}, 'cfmTitleSection')
+  &lt;details class="serverSubsection"&gt;
+    #displaySubsection('caret-down', 'confluencepro.howToMigrate.server.title', 'cfmTitleSection', {})
     &lt;div id="cfmHowToMigrateServerCollapse" class="cfmPrerequisites"&gt;
       #set ($escapedMessage = $escapetool.xml($services.localization.render('confluencepro.packages.serverPath')))
       #set ($editURL = $xwiki.getURL("ConfluenceMigratorPro.Migrations.Migration${datetool.date.time}", 'edit', $escapetool.url({
@@ -169,46 +169,45 @@
 #macro (howToMigrateBatches)
 &lt;div class="howToMigrateSubsection"&gt;
   &lt;details class="batchSubsection"&gt;
-  #displaySubsection('caret-down', 'confluencepro.howToMigrate.batch.title', '', {}, 'cfmTitleSection')
+    #displaySubsection('caret-down', 'confluencepro.howToMigrate.batch.title', 'cfmTitleSection', {})
     &lt;div id="cfmHowToMigrateBatchesCollapse" class="cfmPrerequisites"&gt;
-&lt;div&gt;
-  &lt;a href="$xwiki.getURL('ConfluenceMigratorPro.ConfluenceBatches.New')"&gt;
-    &lt;button id="createNewBatchButton" class='btn btn-primary'&gt;$services.icon.renderHTML('add')
-    $escapetool.xml($services.localization.render('confluencemigratorpro.baches.uploadButton'))&lt;/button&gt;
-  &lt;/a&gt;
-&lt;/div&gt;
-&lt;div&gt;
-  &lt;br/&gt;
-  &lt;span&gt;$escapetool.xml($services.localization.render('confluencemigratorpro.baches.section.hint'))&lt;/span&gt;
-  &lt;br/&gt;
-&lt;/div&gt;
-  #set ($parameters = $escapetool.url({
-    'resultPage': 'ConfluenceMigratorPro.ConfluenceBatches.Code.BatchesLiveDataSource',
-    'translationPrefix': 'confluencemigratorpro.batches.header.'
-  }))
-  #set ($liveDataConfig= {
-    'meta': {
-      'propertyDescriptors': [
-        {'id': 'pageName', 'displayer': 'html'},
-        {'id': 'totalSize', 'displayer': 'html'},
-        {'id': 'creationDate', 'displayer': 'date'},
-        {'id': 'author', 'displayer': 'html'},
-        {'id': 'actions', 'displayer': 'html'}
-      ],
-      'entryDescriptor': {
-        'idProperty': 'pageName'
-      }
-    }
-  })
+      &lt;div&gt;
+        &lt;a href="$xwiki.getURL('ConfluenceMigratorPro.ConfluenceBatches.New')"&gt;
+          &lt;button id="createNewBatchButton" class='btn btn-primary'&gt;$services.icon.renderHTML('add')
+          $escapetool.xml($services.localization.render('confluencemigratorpro.baches.uploadButton'))&lt;/button&gt;
+        &lt;/a&gt;
+      &lt;/div&gt;
+      &lt;div&gt;
+        &lt;br/&gt;
+        &lt;span&gt;$escapetool.xml($services.localization.render('confluencemigratorpro.baches.section.hint'))&lt;/span&gt;
+        &lt;br/&gt;
+      &lt;/div&gt;
+      #set ($parameters = $escapetool.url({
+        'resultPage': 'ConfluenceMigratorPro.ConfluenceBatches.Code.BatchesLiveDataSource',
+        'translationPrefix': 'confluencemigratorpro.batches.header.'
+      }))
+      #set ($liveDataConfig= {
+        'meta': {
+          'propertyDescriptors': [
+            {'id': 'pageName', 'displayer': 'html'},
+            {'id': 'totalSize', 'displayer': 'html'},
+            {'id': 'creationDate', 'displayer': 'date'},
+            {'id': 'author', 'displayer': 'html'},
+            {'id': 'actions', 'displayer': 'html'}
+          ],
+          'entryDescriptor': {
+            'idProperty': 'pageName'
+          }
+        }
+      })
 
-  {{liveData
-    id="confluenceMigratorProBatches"
-    properties="pageName,totalSize, creationDate, author, actions"
-    source='liveTable'
-    sourceParameters="$parameters"
-    sort='creationDate:desc'
-  	limit="10"}}$jsontool.serialize($liveDataConfig){{/liveData}}
-
+      {{liveData
+        id="confluenceMigratorProBatches"
+        properties="pageName,totalSize, creationDate, author, actions"
+        source='liveTable'
+        sourceParameters="$parameters"
+        sort='creationDate:desc'
+        limit="10"}}$jsontool.serialize($liveDataConfig){{/liveData}}
     &lt;/div&gt;
   &lt;/details&gt;
 &lt;/div&gt;

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/Code/Tabs/NewMigration.xml
@@ -45,17 +45,17 @@
 #template('attachment_macros.vm')
 {{/velocity}}
 {{velocity}}
-#macro (displaySubsection $icon $key $class $params)
-&lt;div class="cfmTitle $!class"&gt;
-  &lt;div&gt;
+#macro (displaySubsection $icon $key $class $params $summaryClass)
+&lt;summary class="$summaryClass $!class"&gt;
+  &lt;span&gt;
     &lt;span class="cfmTitleIcon"&gt;
       $services.icon.renderHTML($icon)
     &lt;/span&gt;
     &lt;span&gt;
       $escapetool.xml($services.localization.render($key, $params))
     &lt;/span&gt;
-  &lt;/div&gt;
-&lt;/div&gt;
+  &lt;/span&gt;
+&lt;/summary&gt;
 #end
 #macro (addPrerequisiteToList $list $icon $translationKey $url $params)
   #if ($icon != 'check')
@@ -75,11 +75,9 @@
 
 {{html}}
 &lt;div class="cfmTitle"&gt;
-  &lt;a role="button" data-toggle="collapse" href="#cfmPrerequisitesCollapse" aria-expanded="false" aria-controls="cfmPrerequisitesCollapse"&gt;
-    #displaySubtitle('caret-down', 'confluencepro.prerequisites.title', $prerequisitesComplete, {})
-  &lt;/a&gt;
-&lt;/div&gt;
-&lt;div id="cfmPrerequisitesCollapse" class="cfmPrerequisites collapse"&gt;
+  &lt;details class="cfmPrerequisitesDetails"&gt;
+    #displaySubsection('caret-down', 'confluencepro.prerequisites.title', $prerequisitesComplete, {}, 'cfmTitleSummary')
+  &lt;div class="cfmPrerequisites"&gt;
   &lt;div class="box infomessage"&gt;
     &lt;p&gt;$escapetool.xml($services.localization.render('confluencepro.prerequisites.hint'))&lt;/p&gt;
   &lt;/div&gt;
@@ -98,15 +96,14 @@
   #end
   &lt;/ul&gt;
 &lt;/div&gt;
+&lt;/details&gt;
 {{/html}}
 #end
 #macro (howToMigrateUploadSubsection)
 &lt;div class="howToMigrateSubsection"&gt;
-  &lt;a class="collapsed uploadSubsection" role="button" data-toggle="collapse" href="#cfmHowToMigrateUploadCollapse"
-    aria-expanded="false" aria-controls="cfmHowToMigrateUploadCollapse"&gt;
-  #displaySubsection('caret-down', 'confluencepro.howToMigrate.upload.title', '', {})
-  &lt;/a&gt;
-    &lt;div id="cfmHowToMigrateUploadCollapse" class="collapse"&gt;
+ &lt;details class ="uploadSubsection"&gt;
+  #displaySubsection('caret-down', 'confluencepro.howToMigrate.upload.title', '', {}, 'cfmTitleSection')
+    &lt;div id="cfmHowToMigrateUploadCollapse"&gt;
     &lt;div&gt;
       &lt;button id="facade-upload-button" class="btn btn-primary"&gt;$services.icon.renderHTML('add') $escapetool.xml($services.localization.render('confluencepro.uploadFacadeButton'))&lt;/button&gt;
       &lt;div id='facade-upload-progress'&gt;&lt;/div&gt;
@@ -138,15 +135,14 @@
     {{/html}}
 
   &lt;/div&gt;
+  &lt;/details&gt;
 &lt;/div&gt;
 #end
 #macro (howToMigrateServerSection)
 &lt;div class="howToMigrateSubsection"&gt;
-  &lt;a class="collapsed serverSubsection" role="button" data-toggle="collapse" href="#cfmHowToMigrateServerCollapse"
-    aria-expanded="false" aria-controls="cfmHowToMigrateServerCollapse"&gt;
-  #displaySubsection('caret-down', 'confluencepro.howToMigrate.server.title', '', {})
-  &lt;/a&gt;
-    &lt;div id="cfmHowToMigrateServerCollapse" class="cfmPrerequisites collapse"&gt;
+  &lt;details class = "serverSubsection"&gt;
+  #displaySubsection('caret-down', 'confluencepro.howToMigrate.server.title', '', {}, 'cfmTitleSection')
+    &lt;div id="cfmHowToMigrateServerCollapse" class="cfmPrerequisites"&gt;
       #set ($escapedMessage = $escapetool.xml($services.localization.render('confluencepro.packages.serverPath')))
       #set ($editURL = $xwiki.getURL("ConfluenceMigratorPro.Migrations.Migration${datetool.date.time}", 'edit', $escapetool.url({
         'template': 'ConfluenceMigratorPro.Code.MigrationTemplate',
@@ -167,15 +163,14 @@
 
       &lt;/form&gt;
     &lt;/div&gt;
+  &lt;/details&gt;
 &lt;/div&gt;
 #end
 #macro (howToMigrateBatches)
 &lt;div class="howToMigrateSubsection"&gt;
-  &lt;a class="collapsed batchSubsection" role="button" data-toggle="collapse" href="#cfmHowToMigrateBatchesCollapse"
-    aria-expanded="false" aria-controls="cfmHowToMigrateBatchesCollapse"&gt;
-  #displaySubsection('caret-down', 'confluencepro.howToMigrate.batch.title', '', {})
-  &lt;/a&gt;
-    &lt;div id="cfmHowToMigrateBatchesCollapse" class="cfmPrerequisites collapse"&gt;
+  &lt;details class="batchSubsection"&gt;
+  #displaySubsection('caret-down', 'confluencepro.howToMigrate.batch.title', '', {}, 'cfmTitleSection')
+    &lt;div id="cfmHowToMigrateBatchesCollapse" class="cfmPrerequisites"&gt;
 &lt;div&gt;
   &lt;a href="$xwiki.getURL('ConfluenceMigratorPro.ConfluenceBatches.New')"&gt;
     &lt;button id="createNewBatchButton" class='btn btn-primary'&gt;$services.icon.renderHTML('add')
@@ -215,6 +210,7 @@
   	limit="10"}}$jsontool.serialize($liveDataConfig){{/liveData}}
 
     &lt;/div&gt;
+  &lt;/details&gt;
 &lt;/div&gt;
 #end
 #macro (howToMigrate)
@@ -343,33 +339,30 @@ $xwiki.jsfx.use('js/xwiki/viewers/attachments.js', {'forceSkinAction': true, 'la
       <code>require(['jquery'], function($){
   $('#facade-upload-button').on('click', function(){
     $('#confluenceUploadFile').click();
-  })
+  });
 
-  function areAllCollapsed() {
-    return $('.howToMigrateSubsection &gt; a').toArray().some(el =&gt; !$(el).hasClass('collapsed'));
-}
+  function isAnyOpen() {
+    return $('.howToMigrateSubsection &gt; details').toArray().some(el =&gt; el.open);
+  }
 
   function updateFontWeight() {
-    let collapsed = areAllCollapsed();
-    if (collapsed) {
-      $('.howToMigrateSubsection &gt; a').css('font-weight', 'bold');
-    } else {
-      $('.howToMigrateSubsection &gt; a').css('font-weight', 'normal');
-    }
+    let anyOpen = isAnyOpen();
+    $('.howToMigrateSubsection &gt; details &gt; summary.cfmTitleSection').css(
+      'font-weight', anyOpen ? 'bold' : 'normal'
+    );
   }
 
   // We use an observer because the collapse class is added via js and we might
   // reach some cases were the on click event is handled before the class is added/removed.
   const observer = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {
-      if (mutation.type === 'attributes' &amp;&amp; mutation.attributeName === 'class') {
+      if (mutation.type === 'attributes' &amp;&amp; mutation.attributeName === 'open') {
         updateFontWeight(); // Run the function when class is changed
       }
     });
   });
 
-  $('.howToMigrateSubsection &gt; a').each(function() {
-    console.info('Observer registred');
+  $('.howToMigrateSubsection &gt; details').each(function() {
     observer.observe(this, { attributes: true });
   });
 });</code>

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
@@ -345,6 +345,10 @@
   content: "(${services.localization.render('confluencepro.prerequisites.incomplete')})"
 }
 
+details[open] &gt; summary .cfmTitleIcon {
+  transform: rotate(180deg);
+}
+
 #confluencePackages .attachmentActions a:nth-last-child(2)
 {
   margin: 5px;

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
@@ -365,7 +365,7 @@ details[open] &gt; summary .cfmTitleIcon {
   margin : 20px;
 }
 
-.howToMigrateSubsection &gt; a
+.howToMigrateSubsection
 {
   color: @text-color;
 }
@@ -387,13 +387,6 @@ details[open] &gt; summary .cfmTitleIcon {
 .cmpServerParametersForm label {
   font-weight: normal;
 }
-.howToMigrateSubsection {
-  margin : 20px;
-}
-
-.howToMigrateSubsection &gt; a {
-  color: @text-color;
-}
 
 .confluence-pro-tab-container-new-migration &gt; p {
   display: none !important;
@@ -408,6 +401,16 @@ summary.cfmTitleSection {
 details[open] &gt; summary.cfmTitleSection {
   font-weight: bold;
   text-decoration: underline;
+}
+
+#xwikicontent:has(details[open]) .cfmTitleSection {
+  font-weight: bold;
+}
+
+#cfmHowToMigrateUploadCollapse,
+#cfmHowToMigrateServerCollapse,
+#cfmHowToMigrateBatchesCollapse {
+  margin-top: 1em;
 }</code>
     </property>
     <property>

--- a/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
+++ b/application-confluence-migrator-pro-ui/src/main/resources/ConfluenceMigratorPro/WebHome.xml
@@ -325,20 +325,25 @@
   list-style: none;
 }
 
-.cfmTitle::after {
+.cfmTitleSummary {
+  font-size:1.7rem;
+  line-height:1.3rem;
+  margin:0 0 1rem 0;
+}
+
+.cfmTitleSummary::after {
   font-style: italic;
   color: #bbb;
   margin-left: 0.5em;
 }
 
-.cfmTitle.completed::after {
+.cfmTitleSummary.completed::after {
   content: "(${services.localization.render('confluencepro.prerequisites.completed')})"
 }
 
-.cfmTitle.incomplete::after {
+.cfmTitleSummary.incomplete::after {
   content: "(${services.localization.render('confluencepro.prerequisites.incomplete')})"
 }
-
 
 #confluencePackages .attachmentActions a:nth-last-child(2)
 {
@@ -388,6 +393,17 @@
 
 .confluence-pro-tab-container-new-migration &gt; p {
   display: none !important;
+}
+
+summary.cfmTitleSection {
+  cursor: pointer;
+  list-style: none;
+  font-weight: normal;
+}
+
+details[open] &gt; summary.cfmTitleSection {
+  font-weight: bold;
+  text-decoration: underline;
 }</code>
     </property>
     <property>


### PR DESCRIPTION

# Issue URL

https://github.com/xwikisas/application-confluence-migrator-pro/issues/418 

# Changes
replaced bootstrap / custom (un)folding behavior with details / summary in different sections
## Description

<!-- Describe the main changes brought in this PR. -->

- replaced bootstrap collapse with details/ summary tag in MigrationSheet( the migration raport)
- modified NewMigation page by replacing boostrap collapse with details, summary tags
- modified css in WebHome, CommonCode and js in NewMigation in order to have the same old functionality
- replaced bootstrap collapse in the "New migration" form (when creating a new migration)
- fixed the docker tests after the structure change

## Clarifications
There were accessibility issues with the previous approach with bootstrap collapse, and by getting rid of this and also the animations, the accessibility issues reported have been resolved.

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

# Screenshots & Video

<img width="539" height="310" alt="image" src="https://github.com/user-attachments/assets/19a074c9-e363-4a91-aa5d-3d8b7b501a55" />

<img width="627" height="497" alt="ui" src="https://github.com/user-attachments/assets/a98eab52-928f-4d44-a8a0-242d6ae29140" />

<img width="411" height="193" alt="newMigartion" src="https://github.com/user-attachments/assets/91585c08-5fd2-4295-9302-4a37c35eaa7a" />

# Executed Tests
*fixed the docker tests after the structure change 


* [x] I checked the accessibility of this change (if you don't know what this is about or how to do it, leave this unchecked and don't worry)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
