### PR TITLE
#474: Reference fixing only fixes links for the last migration configured in it #

### DIFF
--- a/application-confluence-migrator-pro-reference-fixer/application-confluence-migrator-pro-reference-fixer-api/src/main/java/com/xwiki/confluencepro/referencefixer/script/ConfluenceReferenceFixerScriptService.java
+++ b/application-confluence-migrator-pro-reference-fixer/application-confluence-migrator-pro-reference-fixer-api/src/main/java/com/xwiki/confluencepro/referencefixer/script/ConfluenceReferenceFixerScriptService.java
@@ -149,17 +149,18 @@ public class ConfluenceReferenceFixerScriptService implements ScriptService
 
     private List<EntityReference> getMigrations(Document statusDocument)
     {
-        List<EntityReference> migrationReferences = Collections.emptyList();
         List<String> migrations = (List<String>) statusDocument.getValue("migrations");
         if (CollectionUtils.isNotEmpty(migrations)) {
+            List<EntityReference> migrationReferences = new ArrayList<>(migrations.size());
             for (String migration : migrations) {
-                migrationReferences = new ArrayList<>(migrations.size());
                 if (StringUtils.isNotEmpty(migration)) {
                     migrationReferences.add(resolver.resolve(migration, EntityType.DOCUMENT));
                 }
             }
+            return migrationReferences;
+        } else {
+            return Collections.emptyList();
         }
-        return migrationReferences;
     }
 
     /**


### PR DESCRIPTION
# Issue URL

https://github.com/xwikisas/application-confluence-migrator-pro/issues/474

# Executed Tests

Tested running reference fixer before the fix: only the last migration was fixed.

Tested with the fix, running the reference fixer after the fix: all migration specified was fixed.

# Expected merging strategy

* Prefers squash: Yes
